### PR TITLE
updating the site with info about 2016 fellowship deadlines

### DIFF
--- a/_site/blog/announcing-2015-fellows/index.html
+++ b/_site/blog/announcing-2015-fellows/index.html
@@ -126,7 +126,7 @@
 <p>Follow Francis on Twitter at <a href="http://www.twitter.com/frnsys">@frnsys</a></p>
 
 </div>
-<small>posted <abbr class="timeago" title="2014-10-22 09:00:00 -0500">2014-10-22 09:00:00 -0500</abbr> | posted in
+<small>posted <abbr class="timeago" title="2014-10-22 09:00:00 -0400">2014-10-22 09:00:00 -0400</abbr> | posted in
 
   
   <a href="/blog/tags/fellowship">fellowship</a>&nbsp;

--- a/_site/blog/code-convening-portland/index.html
+++ b/_site/blog/code-convening-portland/index.html
@@ -99,7 +99,7 @@
 <p>All that effort means Sunday is the finish line, when the journalism community gets shiny new versions of all these tools. With fresh documentation to help you see how they can fit into <em>your</em> newsroom. We can&rsquo;t wait!</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-05-16 12:30:00 -0500">2015-05-16 12:30:00 -0500</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-05-16 12:30:00 -0400">2015-05-16 12:30:00 -0400</abbr> | posted in
 
   
   <a href="/blog/tags/codeconvenings">codeconvenings</a>&nbsp;

--- a/_site/blog/code-convening-wtd/index.html
+++ b/_site/blog/code-convening-wtd/index.html
@@ -101,7 +101,7 @@
 <p>If you and/or your colleagues have a project to release and this code convening sounds like the place to do it, <a href="https://docs.google.com/forms/d/10Fcojz2cIqD96ecErnaQTB37f8i29rCx9HFlnamv-eM/viewform">now is the time to let us know</a>! Proposals will be open through 6 p.m. Eastern this Friday, April 24. We&rsquo;ll consider projects as quickly as possible so we can start making travel plans.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-04-20 14:00:00 -0500">2015-04-20 14:00:00 -0500</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-04-20 14:00:00 -0400">2015-04-20 14:00:00 -0400</abbr> | posted in
 
   
   <a href="/blog/tags/codeconvenings">codeconvenings</a>&nbsp;

--- a/_site/blog/coral-andrew/index.html
+++ b/_site/blog/coral-andrew/index.html
@@ -131,7 +131,7 @@
 <p>More soon.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-04-28 12:30:00 -0500">2015-04-28 12:30:00 -0500</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-04-28 12:30:00 -0400">2015-04-28 12:30:00 -0400</abbr> | posted in
 
   
   <a href="/blog/tags/coralproject">coralproject</a>&nbsp;

--- a/_site/blog/fellowship-2016-partner/index.html
+++ b/_site/blog/fellowship-2016-partner/index.html
@@ -95,7 +95,7 @@
 <p>We&rsquo;ll be available over the next couple of weeks during office hours, at events, and <a href="mailto:info@opennews.org">via email</a> if you have any questions or would like to talk a little more about the fellowship program. Once we receive applications, we&rsquo;ll review all of them and select a group to interview in May. We will announce the 2016 cohort of fellowship partners with the start of the fellowship search in early June. <a href="mailto:info@opennews.org">Drop us a line</a> if you have any questions, and we look forward to learning more about your team.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-04-01 16:15:00 -0500">2015-04-01 16:15:00 -0500</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-04-01 16:15:00 -0400">2015-04-01 16:15:00 -0400</abbr> | posted in
 
   
   <a href="/blog/tags/fellowship">fellowship</a>&nbsp;

--- a/_site/blog/fellowship-onboarding-ccdc/index.html
+++ b/_site/blog/fellowship-onboarding-ccdc/index.html
@@ -115,7 +115,7 @@
 <p>And, of course, the fellows. It&rsquo;s extraordinary to see creative, brilliant people solve problems on the fly, and start to find their place within a group. To see journalism get done by people willing to say, &ldquo;I&rsquo;ve never done this before. Neither have you? OK, let&rsquo;s do it together.&rdquo; That&rsquo;s the tone we wanted to set for this entire fellowship year.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-01-26 12:00:00 -0600">2015-01-26 12:00:00 -0600</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-01-26 12:00:00 -0500">2015-01-26 12:00:00 -0500</abbr> | posted in
 
   
   <a href="/blog/tags/Fellowship">Fellowship</a>&nbsp;

--- a/_site/blog/index.html
+++ b/_site/blog/index.html
@@ -84,97 +84,97 @@
 <ul class = "bloglist">
   
     <li>
-      <p class="blogtitle"><a href="/blog/code-convening-portland">Meet the projects coming to Code Convening&#58; Write The Docs</a><span class="blogdate">| posted <abbr class="timeago" title="2015-05-16 12:30:00 -0500">2015-05-16 12:30:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/code-convening-portland">Meet the projects coming to Code Convening&#58; Write The Docs</a><span class="blogdate">| posted <abbr class="timeago" title="2015-05-16 12:30:00 -0400">2015-05-16 12:30:00 -0400</abbr></span></>
       <p class="excerpt">Meet the seven projects we're bringing to our code convening at Write The Docs 2015.&nbsp;<a href="/blog/code-convening-portland">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-tickets">SRCCON Ticketing—What We Did and Why</a><span class="blogdate">| posted <abbr class="timeago" title="2015-05-12 12:30:00 -0500">2015-05-12 12:30:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-tickets">SRCCON Ticketing—What We Did and Why</a><span class="blogdate">| posted <abbr class="timeago" title="2015-05-12 12:30:00 -0400">2015-05-12 12:30:00 -0400</abbr></span></>
       <p class="excerpt">This year, as we prepare for SRCCON 2015, we're making an effort to document our work in public as we go. This post on our ticketing process will be followed shortly by one on session selection, with more to come between now and the end of June.&nbsp;<a href="/blog/srccon-tickets">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/coral-andrew">The Coral Project is Go Go Go Go Go</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-28 12:30:00 -0500">2015-04-28 12:30:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/coral-andrew">The Coral Project is Go Go Go Go Go</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-28 12:30:00 -0400">2015-04-28 12:30:00 -0400</abbr></span></>
       <p class="excerpt">Exciting things are happening at <a href="https://twitter.com/coralproject">The Coral Project</a> and we thought you should know about them.&nbsp;<a href="/blog/coral-andrew">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srcconqs">Five Reasons You Shouldn't Come to SRCCON (and Why They're All Wrong)</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-22 12:00:00 -0500">2015-04-22 12:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srcconqs">Five Reasons You Shouldn't Come to SRCCON (and Why They're All Wrong)</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-22 12:00:00 -0400">2015-04-22 12:00:00 -0400</abbr></span></>
       <p class="excerpt">Tickets to <a href="http://srccon.org/">SRCCON, the OpenNews conference</a>, go on sale Wednesday, April 29 at 2pm EDT. But maybe you're still on the fence about SRCCON, or are worried that you won't quite fit in. If so, worry no longer—instead, check out our five top reasons why you shouldn't come to SRCCON (and why they're all wrong).&nbsp;<a href="/blog/srcconqs">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/code-convening-wtd">Code Convening&#58; Write The Docs. Come open your code with us!</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-20 14:00:00 -0500">2015-04-20 14:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/code-convening-wtd">Code Convening&#58; Write The Docs. Come open your code with us!</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-20 14:00:00 -0400">2015-04-20 14:00:00 -0400</abbr></span></>
       <p class="excerpt">We'll be taking a cohort of news developers and journalists to the Write The Docs conference, May 17-19 in Portland, to write and revise documentation, release the latest version of their open-source projects, and talk journalism with the technical documentation community.&nbsp;<a href="/blog/code-convening-wtd">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-top5">Five Things We've Learned About Sessions</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-08 18:00:00 -0500">2015-04-08 18:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-top5">Five Things We've Learned About Sessions</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-08 18:00:00 -0400">2015-04-08 18:00:00 -0400</abbr></span></>
       <p class="excerpt">As we near the deadline for SRCCON session proposals (April 10, <a href="http://srccon.org/sessions">pitch now</a>) we wanted to share with you some of what we've learned about sessions so far. Thank you to everyone who shared feedback about last year's conference and helped inform <a href="http://opennews.org/blog/srccon-human-stuff">how we're thinking about things</a> this year.&nbsp;<a href="/blog/srccon-top5">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-session-planning">How to plan a great SRCCON session</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-07 18:00:00 -0500">2015-04-07 18:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-session-planning">How to plan a great SRCCON session</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-07 18:00:00 -0400">2015-04-07 18:00:00 -0400</abbr></span></>
       <p class="excerpt">SRCCON sessions are interactive and collaborative, and if you've never led one, it can be hard to know what to expect. Here are some strategies to help you lead a discussion or skillshare that gets everyone involved and leaves everyone energized.&nbsp;<a href="/blog/srccon-session-planning">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-transcription">Captioning a Multi-Track Conference - How SRCCON Did It</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-02 18:00:00 -0500">2015-04-02 18:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-transcription">Captioning a Multi-Track Conference - How SRCCON Did It</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-02 18:00:00 -0400">2015-04-02 18:00:00 -0400</abbr></span></>
       <p class="excerpt">One of the nerdiest elements of our first SRCCON didn't end up involving code or jokey references. As we were prepping for SRCCON last year, I caught a blog post related to !!Con, <a href="http://composition.al/blog/2014/05/31/your-next-conference-should-have-real-time-captioning/">Your next conference should have real-time captioning</a>. I had never heard of event captioning before. I found the blog post convincing, but we were less than two months away from SRCCON, could we pull off something like this?&nbsp;<a href="/blog/srccon-transcription">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/fellowship-2016-partner">Hosting a Knight-Mozilla Fellow in 2016</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-01 16:15:00 -0500">2015-04-01 16:15:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/fellowship-2016-partner">Hosting a Knight-Mozilla Fellow in 2016</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-01 16:15:00 -0400">2015-04-01 16:15:00 -0400</abbr></span></>
       <p class="excerpt">Next year will be the fifth year of the Knight-Mozilla Fellowship program and we're looking for our next group of fellowship partners. If your news organization is interested in hosting a fellow next year, <a href="http://opennews.org/what/fellowships/partnerguidelines/#form">fill out this form</a> by April 24.&nbsp;<a href="/blog/fellowship-2016-partner">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-human-stuff">Making SRCCON Good for Humans</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-01 09:00:00 -0500">2015-04-01 09:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-human-stuff">Making SRCCON Good for Humans</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-01 09:00:00 -0400">2015-04-01 09:00:00 -0400</abbr></span></>
       <p class="excerpt">We wanted the attendees of SRCCON to be able to focus on the conference itself—sessions, activities, and other official stuff, but also the conversations in hallways and corners that are usually a highlight of gatherings of enthusiastic colleagues. To make that possible, we tried to arrange the SRCCON schedule, space, and life-support systems to be as accommodating and supportive as possible.&nbsp;<a href="/blog/srccon-human-stuff">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/welcome">Welcoming Lindsay Muscato</a><span class="blogdate">| posted <abbr class="timeago" title="2015-03-26 15:00:00 -0500">2015-03-26 15:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/welcome">Welcoming Lindsay Muscato</a><span class="blogdate">| posted <abbr class="timeago" title="2015-03-26 15:00:00 -0400">2015-03-26 15:00:00 -0400</abbr></span></>
       <p class="excerpt">After an involved selection process, we are very happy to introduce <a href="http://lindsaymuscato.com">Lindsay Muscato</a>, Source's new assistant editor, who will be working with us on an upcoming site restructure and leading much of the day-to-day editorial work of keeping Source connected to the news code community.&nbsp;<a href="/blog/welcome">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-proposals">SRCCON Needs You</a><span class="blogdate">| posted <abbr class="timeago" title="2015-03-25 12:00:00 -0500">2015-03-25 12:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-proposals">SRCCON Needs You</a><span class="blogdate">| posted <abbr class="timeago" title="2015-03-25 12:00:00 -0400">2015-03-25 12:00:00 -0400</abbr></span></>
       <p class="excerpt"><a href="http://srccon.org">SRCCON is back in 2015</a> for another two days of building better newsroom code, culture, and process, this time in beautiful Minneapolis. And now it's time for you to <a href="http://srccon.org/sessions/">propose a session</a>.&nbsp;<a href="/blog/srccon-proposals">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/nicar">OpenNews at NICAR</a><span class="blogdate">| posted <abbr class="timeago" title="2015-03-04 07:00:00 -0600">2015-03-04 07:00:00 -0600</abbr></span></>
+      <p class="blogtitle"><a href="/blog/nicar">OpenNews at NICAR</a><span class="blogdate">| posted <abbr class="timeago" title="2015-03-04 07:00:00 -0500">2015-03-04 07:00:00 -0500</abbr></span></>
       <p class="excerpt">We're going to be at NICAR in force this year, and we want to see you there.&nbsp;<a href="/blog/nicar">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-launch">SRCCON 2015 coming to Minneapolis</a><span class="blogdate">| posted <abbr class="timeago" title="2015-02-20 12:00:00 -0600">2015-02-20 12:00:00 -0600</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-launch">SRCCON 2015 coming to Minneapolis</a><span class="blogdate">| posted <abbr class="timeago" title="2015-02-20 12:00:00 -0500">2015-02-20 12:00:00 -0500</abbr></span></>
       <p class="excerpt">We're excited to announce SRCCON 2015, which will take place in Minneapolis, Minnesota on June 25 and 26. We can't wait to spend another two days building better newsroom code, culture, and process—together.&nbsp;<a href="/blog/srccon-launch">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/fellowship-onboarding-ccdc">Fellows Hack with the California Civic Data Coalition</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-26 12:00:00 -0600">2015-01-26 12:00:00 -0600</abbr></span></>
+      <p class="blogtitle"><a href="/blog/fellowship-onboarding-ccdc">Fellows Hack with the California Civic Data Coalition</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-26 12:00:00 -0500">2015-01-26 12:00:00 -0500</abbr></span></>
       <p class="excerpt">During the onboarding week with our new 2015 Knight-Mozilla fellows, we spent a couple days working with the California Civic Data Coalition on an open-source news app. Here's what our goals were, and here's what we learned.&nbsp;<a href="/blog/fellowship-onboarding-ccdc">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/source-hiring">Source is Hiring</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-23 07:00:00 -0600">2015-01-23 07:00:00 -0600</abbr></span></>
+      <p class="blogtitle"><a href="/blog/source-hiring">Source is Hiring</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-23 07:00:00 -0500">2015-01-23 07:00:00 -0500</abbr></span></>
       <p class="excerpt">OpenNews is hiring a part-time assistant editor on a contract basis for Source, our journalism-code community website—and you should totally apply.&nbsp;<a href="/blog/source-hiring">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/new-site">New Year, New Site</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-16 10:00:00 -0600">2015-01-16 10:00:00 -0600</abbr></span></>
+      <p class="blogtitle"><a href="/blog/new-site">New Year, New Site</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-16 10:00:00 -0500">2015-01-16 10:00:00 -0500</abbr></span></>
       <p class="excerpt">While our 2015 Knight-Mozilla fellows have been in Los Angeles, getting to know each other and the world of newsroom code, we’ve given OpenNews.org a haircut and re-org to reflect the work we’re actually doing.&nbsp;<a href="/blog/new-site">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/introducing-kavya">2015 Fellowship Onboarding is GO</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-12 09:00:00 -0600">2015-01-12 09:00:00 -0600</abbr></span></>
+      <p class="blogtitle"><a href="/blog/introducing-kavya">2015 Fellowship Onboarding is GO</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-12 09:00:00 -0500">2015-01-12 09:00:00 -0500</abbr></span></>
       <p class="excerpt">The OpenNews team brings our 2015 Knight-Mozilla Fellows to Los Angeles to start the work of their fellowship years. We also welcome Kavya Sukumar as our seventh 2015 fellow, who will spend her fellowship year working with Vox Media. Yay fellows! Yay Los Angeles!&nbsp;<a href="/blog/introducing-kavya">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/announcing-2015-fellows">Announcing our 2015 Knight-Mozilla Fellows!</a><span class="blogdate">| posted <abbr class="timeago" title="2014-10-22 09:00:00 -0500">2014-10-22 09:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/announcing-2015-fellows">Announcing our 2015 Knight-Mozilla Fellows!</a><span class="blogdate">| posted <abbr class="timeago" title="2014-10-22 09:00:00 -0400">2014-10-22 09:00:00 -0400</abbr></span></>
       <p class="excerpt">Live from the 2014 Mozilla Festival in London, we're thrilled to introduce our 2015 Knight-Mozilla Fellows. The work that the Knight-Mozilla Fellows do during their fellowship year doesn't fit easily into a single sentence. Over the year a fellow will play the role of coder, teacher, mentor (and mentee), adventurer, colleague, and friend. They'll push themselves, and journalism, in new directions. They'll do work that has real impact--on themselves and on the web. It's a tall order, but a thrilling one, and the people we have lined up to do the work of a Knight-Mozilla Fellow in 2015 are among our very best yet. I can't wait for you to meet them.&nbsp;<a href="/blog/announcing-2015-fellows">read more</a>
     </li>
   

--- a/_site/blog/introducing-kavya/index.html
+++ b/_site/blog/introducing-kavya/index.html
@@ -88,7 +88,7 @@
 <p>We&rsquo;re thrilled to have Kavya join the <a href="/what/fellowships/2015meet">already-amazing cohort of 2015 Knight-Mozilla Fellows</a>, and excited to have all of them together with us in LA this week. There&rsquo;s so much more to come in 2015 from <a href="http://opennews.org/">OpenNews</a>, and it feels great to kick off an incredible year with these incredible people.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-01-12 09:00:00 -0600">2015-01-12 09:00:00 -0600</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-01-12 09:00:00 -0500">2015-01-12 09:00:00 -0500</abbr> | posted in
 
   
   <a href="/blog/tags/fellowship">fellowship</a>&nbsp;

--- a/_site/blog/new-site/index.html
+++ b/_site/blog/new-site/index.html
@@ -84,7 +84,7 @@
 <p>As always, we’re working in the open, so <a href="https://github.com/mozilla/mozilla-opennews">the site’s up on GitHub</a>, and we welcome your comments, bug reports, and pull requests.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-01-16 10:00:00 -0600">2015-01-16 10:00:00 -0600</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-01-16 10:00:00 -0500">2015-01-16 10:00:00 -0500</abbr> | posted in
 
   
   <a href="/blog/tags/housekeeping">housekeeping</a>&nbsp;

--- a/_site/blog/nicar/index.html
+++ b/_site/blog/nicar/index.html
@@ -133,7 +133,7 @@
 <p>Are you the only developer or data nerd in your newsroom? We want to buy you lunch! Come hang out with others in the same situation, trade tips, and make contacts for long-distance pair work. <a href="https://www.eventbrite.com/e/lonely-coders-lunch-tickets-15977120999">The lunch is now full</a>, but <a href="http://ire.org/events-and-training/event/1494/1777/">check out the related panel later Saturday afternoon</a>.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-03-04 07:00:00 -0600">2015-03-04 07:00:00 -0600</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-03-04 07:00:00 -0500">2015-03-04 07:00:00 -0500</abbr> | posted in
 
   
   <a href="/blog/tags/NICAR">NICAR</a>&nbsp;

--- a/_site/blog/source-hiring/index.html
+++ b/_site/blog/source-hiring/index.html
@@ -94,7 +94,7 @@
 <p>Please <a href="mailto:info@opennews.org">send us a short email/cover letter</a> and include links to a resume or portfolio—or paste a plain text resume into the email, or whatever else makes sense, as long as it&rsquo;s not an attachment. Put &ldquo;Assistant Editor&rdquo; somewhere in the subject line. That&rsquo;s it. Wooo!</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-01-23 07:00:00 -0600">2015-01-23 07:00:00 -0600</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-01-23 07:00:00 -0500">2015-01-23 07:00:00 -0500</abbr> | posted in
 
   
   <a href="/blog/tags/Source">Source</a>&nbsp;

--- a/_site/blog/srccon-human-stuff/index.html
+++ b/_site/blog/srccon-human-stuff/index.html
@@ -129,7 +129,7 @@
 <p>As always, we thrive on feedback and questions, so please <a href="mailto:srccon@opennews.org">send us a note</a> if you have either one.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-04-01 09:00:00 -0500">2015-04-01 09:00:00 -0500</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-04-01 09:00:00 -0400">2015-04-01 09:00:00 -0400</abbr> | posted in
 
   
   <a href="/blog/tags/SRCCON">SRCCON</a>&nbsp;

--- a/_site/blog/srccon-launch/index.html
+++ b/_site/blog/srccon-launch/index.html
@@ -87,7 +87,7 @@ Last year was the inaugural SRCCON, and we had <a href="http://data.qz.com/srcco
 <p>SRCCON. Minneapolis. June 25+26. Hope to see you there.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-02-20 12:00:00 -0600">2015-02-20 12:00:00 -0600</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-02-20 12:00:00 -0500">2015-02-20 12:00:00 -0500</abbr> | posted in
 
   
   <a href="/blog/tags/SRCCON">SRCCON</a>&nbsp;

--- a/_site/blog/srccon-proposals/index.html
+++ b/_site/blog/srccon-proposals/index.html
@@ -92,7 +92,7 @@
 <p>Our <a href="http://opennews.org/what/community/calls/">April 1 community call</a> will include a SRCCON session Q&amp;A, and we&rsquo;ll be holding virtual office hours on April 1 and 7 to help with proposals, answer questions, and provide general encouragement to everyone interested in proposing a session. Follow <a href="https://twitter.com/srccon">@SRCCON</a> or <a href="https://twitter.com/opennews">@OpenNews</a> on Twitter to get notifications of these and other SRCCON-related events.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-03-25 12:00:00 -0500">2015-03-25 12:00:00 -0500</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-03-25 12:00:00 -0400">2015-03-25 12:00:00 -0400</abbr> | posted in
 
   
   <a href="/blog/tags/SRCCON">SRCCON</a>&nbsp;

--- a/_site/blog/srccon-session-planning/index.html
+++ b/_site/blog/srccon-session-planning/index.html
@@ -127,7 +127,7 @@
 <p>SRCCON sessions work best when your audience is as engaged as you are, and walking in with a plan can make that happen. We hope these guidelines get you thinking, and if you have your own thoughts to share, <a href="mailto:srccon@opennews.org">let us know</a>! We&rsquo;ll keep updating this document with more questions and ideas.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-04-07 18:00:00 -0500">2015-04-07 18:00:00 -0500</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-04-07 18:00:00 -0400">2015-04-07 18:00:00 -0400</abbr> | posted in
 
   
   <a href="/blog/tags/SRCCON">SRCCON</a>&nbsp;

--- a/_site/blog/srccon-tickets/index.html
+++ b/_site/blog/srccon-tickets/index.html
@@ -141,7 +141,7 @@
 <p>Like everything else to do with OpenNews and SRCCON, our ticketing is an iterative process. When we hold SRCCON in 2016, we&rsquo;ll probably handle it a little differently—but it&rsquo;s hard to say how, at this point. We&rsquo;ll want to preserve the scale of the event and the human benefits it brings, so once again, we&rsquo;ll have to make a whole set of difficult decisions. In the interim, we welcome feedback and will continue to aim for the most fair, ethical, transparent process we can come up with—for tickets and everything else.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-05-12 12:30:00 -0500">2015-05-12 12:30:00 -0500</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-05-12 12:30:00 -0400">2015-05-12 12:30:00 -0400</abbr> | posted in
 
   
   <a href="/blog/tags/srccon">srccon</a>&nbsp;

--- a/_site/blog/srccon-top5/index.html
+++ b/_site/blog/srccon-top5/index.html
@@ -96,7 +96,7 @@ This is not a requirement for SRCCON sessions, but it&rsquo;s just so great when
 <p>We&rsquo;ve received a score of <a href="http://srccon.org/sessions/proposals">session proposals</a> already, and we can&rsquo;t wait to review them all after midnight Pacific time on April 10. We&rsquo;ll have these considerations in mind as we construct the final schedule, and we <a href="mailto:srccon@opennews.org">always welcome additional feedback</a> about how to make sure SRCCON is welcoming and productive for all participants.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-04-08 18:00:00 -0500">2015-04-08 18:00:00 -0500</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-04-08 18:00:00 -0400">2015-04-08 18:00:00 -0400</abbr> | posted in
 
   
   <a href="/blog/tags/SRCCON">SRCCON</a>&nbsp;

--- a/_site/blog/srccon-transcription/index.html
+++ b/_site/blog/srccon-transcription/index.html
@@ -117,7 +117,7 @@
 <p>We&rsquo;re really looking forward to having live transcription again at SRCCON this year. I&rsquo;m also excited to hear it being talked about for other conferences and I am always available <a href="mailto:erika@mozillafoundation.org">to chat more</a> about our experience. Accessibility: it&rsquo;s the right thing to do, plus it can be super nerdy fun.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-04-02 18:00:00 -0500">2015-04-02 18:00:00 -0500</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-04-02 18:00:00 -0400">2015-04-02 18:00:00 -0400</abbr> | posted in
 
   
   <a href="/blog/tags/SRCCON">SRCCON</a>&nbsp;

--- a/_site/blog/srcconqs/index.html
+++ b/_site/blog/srcconqs/index.html
@@ -114,7 +114,7 @@
 <p>We offer licensed, on-site childcare at the conference hotel across the street from the venue, which is ADA-compliant. The catering staff can handle just about any dietary requirements, and our whole event crew is dedicated to getting accommodations right and making sure it all works on the ground. If you have questions about specific accommodations, <a href="mailto:srccon@opennews.org">send us a note</a>  and we&rsquo;ll get right back to you.</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-04-22 12:00:00 -0500">2015-04-22 12:00:00 -0500</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-04-22 12:00:00 -0400">2015-04-22 12:00:00 -0400</abbr> | posted in
 
   
   <a href="/blog/tags/srccon">srccon</a>&nbsp;

--- a/_site/blog/tags/NICAR/index.html
+++ b/_site/blog/tags/NICAR/index.html
@@ -130,7 +130,7 @@
   
   
   <li class="archive_list">
-    <a class="archive_list_article_link" href='/blog/nicar'>OpenNews at NICAR</a>  | posted <abbr class="timeago" title="2015-03-04 07:00:00 -0600">2015-03-04 07:00:00 -0600</abbr>
+    <a class="archive_list_article_link" href='/blog/nicar'>OpenNews at NICAR</a>  | posted <abbr class="timeago" title="2015-03-04 07:00:00 -0500">2015-03-04 07:00:00 -0500</abbr>
     <p class="summary">
   <!--  <ul class="tag_list">
       

--- a/_site/blog/tags/SRCCON/index.html
+++ b/_site/blog/tags/SRCCON/index.html
@@ -3,7 +3,7 @@
 <html class="no-js">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>Posts Tagged &ldquo;srccon&rdquo; | Knight-Mozilla OpenNews</title>
+    <title>Posts Tagged &ldquo;SRCCON&rdquo; | Knight-Mozilla OpenNews</title>
     <link rel="alternate" type="application/atom+xml" title="Atom 0.3"  href="http://planet.opennews.org/rss" />
      <meta name="Description" content="Knight-Mozilla OpenNews is about creating a diverse ecosystem to help journalism thrive on the open web. It's about producing open source code that solves real problems in news. It's about supporting communities of developers and journalists as they make, learn, and invent together. And it's about deploying fellows&mdash;and code&mdash;into news organizations to collaborate in new ways..">
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
@@ -74,7 +74,7 @@
     </header>
         <article>
             <div class="main_col">
-            <h2 class="post_title">Posts Tagged &ldquo;srccon&rdquo;</h2>
+            <h2 class="post_title">Posts Tagged &ldquo;SRCCON&rdquo;</h2>
 <ul>
   
   
@@ -83,12 +83,76 @@
   
   
   
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
   <li class="archive_list">
-    <a class="archive_list_article_link" href='/blog/srccon-tickets'>SRCCON Ticketing—What We Did and Why</a>  | posted <abbr class="timeago" title="2015-05-12 12:30:00 -0500">2015-05-12 12:30:00 -0500</abbr>
+    <a class="archive_list_article_link" href='/blog/srccon-top5'>Five Things We've Learned About Sessions</a>  | posted <abbr class="timeago" title="2015-04-08 18:00:00 -0400">2015-04-08 18:00:00 -0400</abbr>
     <p class="summary">
   <!--  <ul class="tag_list">
       
-      <li class="inline archive_list"><a class="tag_list_link" href="/tag/srccon">srccon</a></li>
+      <li class="inline archive_list"><a class="tag_list_link" href="/tag/SRCCON">SRCCON</a></li>
+      
+    </ul> -->
+  </li>
+  
+  
+  
+  
+  
+  <li class="archive_list">
+    <a class="archive_list_article_link" href='/blog/srccon-session-planning'>How to plan a great SRCCON session</a>  | posted <abbr class="timeago" title="2015-04-07 18:00:00 -0400">2015-04-07 18:00:00 -0400</abbr>
+    <p class="summary">
+  <!--  <ul class="tag_list">
+      
+      <li class="inline archive_list"><a class="tag_list_link" href="/tag/SRCCON">SRCCON</a></li>
+      
+    </ul> -->
+  </li>
+  
+  
+  
+  
+  
+  <li class="archive_list">
+    <a class="archive_list_article_link" href='/blog/srccon-transcription'>Captioning a Multi-Track Conference - How SRCCON Did It</a>  | posted <abbr class="timeago" title="2015-04-02 18:00:00 -0400">2015-04-02 18:00:00 -0400</abbr>
+    <p class="summary">
+  <!--  <ul class="tag_list">
+      
+      <li class="inline archive_list"><a class="tag_list_link" href="/tag/SRCCON">SRCCON</a></li>
+      
+    </ul> -->
+  </li>
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  <li class="archive_list">
+    <a class="archive_list_article_link" href='/blog/srccon-human-stuff'>Making SRCCON Good for Humans</a>  | posted <abbr class="timeago" title="2015-04-01 09:00:00 -0400">2015-04-01 09:00:00 -0400</abbr>
+    <p class="summary">
+  <!--  <ul class="tag_list">
+      
+      <li class="inline archive_list"><a class="tag_list_link" href="/tag/SRCCON">SRCCON</a></li>
       
     </ul> -->
   </li>
@@ -102,11 +166,11 @@
   
   
   <li class="archive_list">
-    <a class="archive_list_article_link" href='/blog/srcconqs'>Five Reasons You Shouldn't Come to SRCCON (and Why They're All Wrong)</a>  | posted <abbr class="timeago" title="2015-04-22 12:00:00 -0500">2015-04-22 12:00:00 -0500</abbr>
+    <a class="archive_list_article_link" href='/blog/srccon-proposals'>SRCCON Needs You</a>  | posted <abbr class="timeago" title="2015-03-25 12:00:00 -0400">2015-03-25 12:00:00 -0400</abbr>
     <p class="summary">
   <!--  <ul class="tag_list">
       
-      <li class="inline archive_list"><a class="tag_list_link" href="/tag/srccon">srccon</a></li>
+      <li class="inline archive_list"><a class="tag_list_link" href="/tag/SRCCON">SRCCON</a></li>
       
     </ul> -->
   </li>
@@ -119,39 +183,15 @@
   
   
   
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
+  <li class="archive_list">
+    <a class="archive_list_article_link" href='/blog/srccon-launch'>SRCCON 2015 coming to Minneapolis</a>  | posted <abbr class="timeago" title="2015-02-20 12:00:00 -0500">2015-02-20 12:00:00 -0500</abbr>
+    <p class="summary">
+  <!--  <ul class="tag_list">
+      
+      <li class="inline archive_list"><a class="tag_list_link" href="/tag/SRCCON">SRCCON</a></li>
+      
+    </ul> -->
+  </li>
   
   
   

--- a/_site/blog/tags/Source/index.html
+++ b/_site/blog/tags/Source/index.html
@@ -122,7 +122,7 @@
   
   
   <li class="archive_list">
-    <a class="archive_list_article_link" href='/blog/welcome'>Welcoming Lindsay Muscato</a>  | posted <abbr class="timeago" title="2015-03-26 15:00:00 -0500">2015-03-26 15:00:00 -0500</abbr>
+    <a class="archive_list_article_link" href='/blog/welcome'>Welcoming Lindsay Muscato</a>  | posted <abbr class="timeago" title="2015-03-26 15:00:00 -0400">2015-03-26 15:00:00 -0400</abbr>
     <p class="summary">
   <!--  <ul class="tag_list">
       
@@ -152,7 +152,7 @@
   
   
   <li class="archive_list">
-    <a class="archive_list_article_link" href='/blog/source-hiring'>Source is Hiring</a>  | posted <abbr class="timeago" title="2015-01-23 07:00:00 -0600">2015-01-23 07:00:00 -0600</abbr>
+    <a class="archive_list_article_link" href='/blog/source-hiring'>Source is Hiring</a>  | posted <abbr class="timeago" title="2015-01-23 07:00:00 -0500">2015-01-23 07:00:00 -0500</abbr>
     <p class="summary">
   <!--  <ul class="tag_list">
       

--- a/_site/blog/tags/announcements/index.html
+++ b/_site/blog/tags/announcements/index.html
@@ -114,7 +114,7 @@
   
   
   <li class="archive_list">
-    <a class="archive_list_article_link" href='/blog/fellowship-2016-partner'>Hosting a Knight-Mozilla Fellow in 2016</a>  | posted <abbr class="timeago" title="2015-04-01 16:15:00 -0500">2015-04-01 16:15:00 -0500</abbr>
+    <a class="archive_list_article_link" href='/blog/fellowship-2016-partner'>Hosting a Knight-Mozilla Fellow in 2016</a>  | posted <abbr class="timeago" title="2015-04-01 16:15:00 -0400">2015-04-01 16:15:00 -0400</abbr>
     <p class="summary">
   <!--  <ul class="tag_list">
       
@@ -164,7 +164,7 @@
   
   
   <li class="archive_list">
-    <a class="archive_list_article_link" href='/blog/introducing-kavya'>2015 Fellowship Onboarding is GO</a>  | posted <abbr class="timeago" title="2015-01-12 09:00:00 -0600">2015-01-12 09:00:00 -0600</abbr>
+    <a class="archive_list_article_link" href='/blog/introducing-kavya'>2015 Fellowship Onboarding is GO</a>  | posted <abbr class="timeago" title="2015-01-12 09:00:00 -0500">2015-01-12 09:00:00 -0500</abbr>
     <p class="summary">
   <!--  <ul class="tag_list">
       
@@ -182,7 +182,7 @@
   
   
   <li class="archive_list">
-    <a class="archive_list_article_link" href='/blog/announcing-2015-fellows'>Announcing our 2015 Knight-Mozilla Fellows!</a>  | posted <abbr class="timeago" title="2014-10-22 09:00:00 -0500">2014-10-22 09:00:00 -0500</abbr>
+    <a class="archive_list_article_link" href='/blog/announcing-2015-fellows'>Announcing our 2015 Knight-Mozilla Fellows!</a>  | posted <abbr class="timeago" title="2014-10-22 09:00:00 -0400">2014-10-22 09:00:00 -0400</abbr>
     <p class="summary">
   <!--  <ul class="tag_list">
       

--- a/_site/blog/tags/codeconvenings/index.html
+++ b/_site/blog/tags/codeconvenings/index.html
@@ -80,7 +80,7 @@
   
   
   <li class="archive_list">
-    <a class="archive_list_article_link" href='/blog/code-convening-portland'>Meet the projects coming to Code Convening&#58; Write The Docs</a>  | posted <abbr class="timeago" title="2015-05-16 12:30:00 -0500">2015-05-16 12:30:00 -0500</abbr>
+    <a class="archive_list_article_link" href='/blog/code-convening-portland'>Meet the projects coming to Code Convening&#58; Write The Docs</a>  | posted <abbr class="timeago" title="2015-05-16 12:30:00 -0400">2015-05-16 12:30:00 -0400</abbr>
     <p class="summary">
   <!--  <ul class="tag_list">
       
@@ -106,7 +106,7 @@
   
   
   <li class="archive_list">
-    <a class="archive_list_article_link" href='/blog/code-convening-wtd'>Code Convening&#58; Write The Docs. Come open your code with us!</a>  | posted <abbr class="timeago" title="2015-04-20 14:00:00 -0500">2015-04-20 14:00:00 -0500</abbr>
+    <a class="archive_list_article_link" href='/blog/code-convening-wtd'>Code Convening&#58; Write The Docs. Come open your code with us!</a>  | posted <abbr class="timeago" title="2015-04-20 14:00:00 -0400">2015-04-20 14:00:00 -0400</abbr>
     <p class="summary">
   <!--  <ul class="tag_list">
       

--- a/_site/blog/tags/coralproject/index.html
+++ b/_site/blog/tags/coralproject/index.html
@@ -88,7 +88,7 @@
   
   
   <li class="archive_list">
-    <a class="archive_list_article_link" href='/blog/coral-andrew'>The Coral Project is Go Go Go Go Go</a>  | posted <abbr class="timeago" title="2015-04-28 12:30:00 -0500">2015-04-28 12:30:00 -0500</abbr>
+    <a class="archive_list_article_link" href='/blog/coral-andrew'>The Coral Project is Go Go Go Go Go</a>  | posted <abbr class="timeago" title="2015-04-28 12:30:00 -0400">2015-04-28 12:30:00 -0400</abbr>
     <p class="summary">
   <!--  <ul class="tag_list">
       

--- a/_site/blog/tags/fellowship/index.html
+++ b/_site/blog/tags/fellowship/index.html
@@ -3,7 +3,7 @@
 <html class="no-js">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>Posts Tagged &ldquo;Fellowship&rdquo; | Knight-Mozilla OpenNews</title>
+    <title>Posts Tagged &ldquo;fellowship&rdquo; | Knight-Mozilla OpenNews</title>
     <link rel="alternate" type="application/atom+xml" title="Atom 0.3"  href="http://planet.opennews.org/rss" />
      <meta name="Description" content="Knight-Mozilla OpenNews is about creating a diverse ecosystem to help journalism thrive on the open web. It's about producing open source code that solves real problems in news. It's about supporting communities of developers and journalists as they make, learn, and invent together. And it's about deploying fellows&mdash;and code&mdash;into news organizations to collaborate in new ways..">
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
@@ -74,7 +74,7 @@
     </header>
         <article>
             <div class="main_col">
-            <h2 class="post_title">Posts Tagged &ldquo;Fellowship&rdquo;</h2>
+            <h2 class="post_title">Posts Tagged &ldquo;fellowship&rdquo;</h2>
 <ul>
   
   
@@ -98,6 +98,30 @@
   
   
   
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  <li class="archive_list">
+    <a class="archive_list_article_link" href='/blog/fellowship-2016-partner'>Hosting a Knight-Mozilla Fellow in 2016</a>  | posted <abbr class="timeago" title="2015-04-01 16:15:00 -0400">2015-04-01 16:15:00 -0400</abbr>
+    <p class="summary">
+  <!--  <ul class="tag_list">
+      
+      <li class="inline archive_list"><a class="tag_list_link" href="/tag/fellowship">fellowship</a></li>
+      
+      <li class="inline archive_list"><a class="tag_list_link" href="/tag/announcements">announcements</a></li>
+      
+    </ul> -->
+  </li>
   
   
   
@@ -138,11 +162,13 @@
   
   
   <li class="archive_list">
-    <a class="archive_list_article_link" href='/blog/fellowship-onboarding-ccdc'>Fellows Hack with the California Civic Data Coalition</a>  | posted <abbr class="timeago" title="2015-01-26 12:00:00 -0600">2015-01-26 12:00:00 -0600</abbr>
+    <a class="archive_list_article_link" href='/blog/introducing-kavya'>2015 Fellowship Onboarding is GO</a>  | posted <abbr class="timeago" title="2015-01-12 09:00:00 -0500">2015-01-12 09:00:00 -0500</abbr>
     <p class="summary">
   <!--  <ul class="tag_list">
       
-      <li class="inline archive_list"><a class="tag_list_link" href="/tag/Fellowship">Fellowship</a></li>
+      <li class="inline archive_list"><a class="tag_list_link" href="/tag/fellowship">fellowship</a></li>
+      
+      <li class="inline archive_list"><a class="tag_list_link" href="/tag/announcements">announcements</a></li>
       
     </ul> -->
   </li>
@@ -153,17 +179,17 @@
   
   
   
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
+  <li class="archive_list">
+    <a class="archive_list_article_link" href='/blog/announcing-2015-fellows'>Announcing our 2015 Knight-Mozilla Fellows!</a>  | posted <abbr class="timeago" title="2014-10-22 09:00:00 -0400">2014-10-22 09:00:00 -0400</abbr>
+    <p class="summary">
+  <!--  <ul class="tag_list">
+      
+      <li class="inline archive_list"><a class="tag_list_link" href="/tag/fellowship">fellowship</a></li>
+      
+      <li class="inline archive_list"><a class="tag_list_link" href="/tag/announcements">announcements</a></li>
+      
+    </ul> -->
+  </li>
   
   
   

--- a/_site/blog/tags/housekeeping/index.html
+++ b/_site/blog/tags/housekeeping/index.html
@@ -146,7 +146,7 @@
   
   
   <li class="archive_list">
-    <a class="archive_list_article_link" href='/blog/new-site'>New Year, New Site</a>  | posted <abbr class="timeago" title="2015-01-16 10:00:00 -0600">2015-01-16 10:00:00 -0600</abbr>
+    <a class="archive_list_article_link" href='/blog/new-site'>New Year, New Site</a>  | posted <abbr class="timeago" title="2015-01-16 10:00:00 -0500">2015-01-16 10:00:00 -0500</abbr>
     <p class="summary">
   <!--  <ul class="tag_list">
       

--- a/_site/blog/tags/index.html
+++ b/_site/blog/tags/index.html
@@ -79,94 +79,94 @@
 <p>  <h3 id="Fellowship"><a href="Fellowship">Fellowship</a></h3>
   <ul></p>
 
-<p>  <li><a href="/blog/fellowship-onboarding-ccdc">Fellows Hack with the California Civic Data Coalition</a> | posted <abbr class="timeago" title="2015-01-26 12:00:00 -0600">2015-01-26 12:00:00 -0600</abbr></li></p>
+<p>  <li><a href="/blog/fellowship-onboarding-ccdc">Fellows Hack with the California Civic Data Coalition</a> | posted <abbr class="timeago" title="2015-01-26 12:00:00 -0500">2015-01-26 12:00:00 -0500</abbr></li></p>
 
 <p>  </ul></p>
 
 <p>  <h3 id="NICAR"><a href="NICAR">NICAR</a></h3>
   <ul></p>
 
-<p>  <li><a href="/blog/nicar">OpenNews at NICAR</a> | posted <abbr class="timeago" title="2015-03-04 07:00:00 -0600">2015-03-04 07:00:00 -0600</abbr></li></p>
+<p>  <li><a href="/blog/nicar">OpenNews at NICAR</a> | posted <abbr class="timeago" title="2015-03-04 07:00:00 -0500">2015-03-04 07:00:00 -0500</abbr></li></p>
 
 <p>  </ul></p>
 
 <p>  <h3 id="SRCCON"><a href="SRCCON">SRCCON</a></h3>
   <ul></p>
 
-<p>  <li><a href="/blog/srccon-top5">Five Things We&rsquo;ve Learned About Sessions</a> | posted <abbr class="timeago" title="2015-04-08 18:00:00 -0500">2015-04-08 18:00:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/srccon-top5">Five Things We&rsquo;ve Learned About Sessions</a> | posted <abbr class="timeago" title="2015-04-08 18:00:00 -0400">2015-04-08 18:00:00 -0400</abbr></li></p>
 
-<p>  <li><a href="/blog/srccon-session-planning">How to plan a great SRCCON session</a> | posted <abbr class="timeago" title="2015-04-07 18:00:00 -0500">2015-04-07 18:00:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/srccon-session-planning">How to plan a great SRCCON session</a> | posted <abbr class="timeago" title="2015-04-07 18:00:00 -0400">2015-04-07 18:00:00 -0400</abbr></li></p>
 
-<p>  <li><a href="/blog/srccon-transcription">Captioning a Multi-Track Conference - How SRCCON Did It</a> | posted <abbr class="timeago" title="2015-04-02 18:00:00 -0500">2015-04-02 18:00:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/srccon-transcription">Captioning a Multi-Track Conference - How SRCCON Did It</a> | posted <abbr class="timeago" title="2015-04-02 18:00:00 -0400">2015-04-02 18:00:00 -0400</abbr></li></p>
 
-<p>  <li><a href="/blog/srccon-human-stuff">Making SRCCON Good for Humans</a> | posted <abbr class="timeago" title="2015-04-01 09:00:00 -0500">2015-04-01 09:00:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/srccon-human-stuff">Making SRCCON Good for Humans</a> | posted <abbr class="timeago" title="2015-04-01 09:00:00 -0400">2015-04-01 09:00:00 -0400</abbr></li></p>
 
-<p>  <li><a href="/blog/srccon-proposals">SRCCON Needs You</a> | posted <abbr class="timeago" title="2015-03-25 12:00:00 -0500">2015-03-25 12:00:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/srccon-proposals">SRCCON Needs You</a> | posted <abbr class="timeago" title="2015-03-25 12:00:00 -0400">2015-03-25 12:00:00 -0400</abbr></li></p>
 
-<p>  <li><a href="/blog/srccon-launch">SRCCON 2015 coming to Minneapolis</a> | posted <abbr class="timeago" title="2015-02-20 12:00:00 -0600">2015-02-20 12:00:00 -0600</abbr></li></p>
+<p>  <li><a href="/blog/srccon-launch">SRCCON 2015 coming to Minneapolis</a> | posted <abbr class="timeago" title="2015-02-20 12:00:00 -0500">2015-02-20 12:00:00 -0500</abbr></li></p>
 
 <p>  </ul></p>
 
 <p>  <h3 id="Source"><a href="Source">Source</a></h3>
   <ul></p>
 
-<p>  <li><a href="/blog/welcome">Welcoming Lindsay Muscato</a> | posted <abbr class="timeago" title="2015-03-26 15:00:00 -0500">2015-03-26 15:00:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/welcome">Welcoming Lindsay Muscato</a> | posted <abbr class="timeago" title="2015-03-26 15:00:00 -0400">2015-03-26 15:00:00 -0400</abbr></li></p>
 
-<p>  <li><a href="/blog/source-hiring">Source is Hiring</a> | posted <abbr class="timeago" title="2015-01-23 07:00:00 -0600">2015-01-23 07:00:00 -0600</abbr></li></p>
+<p>  <li><a href="/blog/source-hiring">Source is Hiring</a> | posted <abbr class="timeago" title="2015-01-23 07:00:00 -0500">2015-01-23 07:00:00 -0500</abbr></li></p>
 
 <p>  </ul></p>
 
 <p>  <h3 id="announcements"><a href="announcements">announcements</a></h3>
   <ul></p>
 
-<p>  <li><a href="/blog/fellowship-2016-partner">Hosting a Knight-Mozilla Fellow in 2016</a> | posted <abbr class="timeago" title="2015-04-01 16:15:00 -0500">2015-04-01 16:15:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/fellowship-2016-partner">Hosting a Knight-Mozilla Fellow in 2016</a> | posted <abbr class="timeago" title="2015-04-01 16:15:00 -0400">2015-04-01 16:15:00 -0400</abbr></li></p>
 
-<p>  <li><a href="/blog/introducing-kavya">2015 Fellowship Onboarding is GO</a> | posted <abbr class="timeago" title="2015-01-12 09:00:00 -0600">2015-01-12 09:00:00 -0600</abbr></li></p>
+<p>  <li><a href="/blog/introducing-kavya">2015 Fellowship Onboarding is GO</a> | posted <abbr class="timeago" title="2015-01-12 09:00:00 -0500">2015-01-12 09:00:00 -0500</abbr></li></p>
 
-<p>  <li><a href="/blog/announcing-2015-fellows">Announcing our 2015 Knight-Mozilla Fellows!</a> | posted <abbr class="timeago" title="2014-10-22 09:00:00 -0500">2014-10-22 09:00:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/announcing-2015-fellows">Announcing our 2015 Knight-Mozilla Fellows!</a> | posted <abbr class="timeago" title="2014-10-22 09:00:00 -0400">2014-10-22 09:00:00 -0400</abbr></li></p>
 
 <p>  </ul></p>
 
 <p>  <h3 id="codeconvenings"><a href="codeconvenings">codeconvenings</a></h3>
   <ul></p>
 
-<p>  <li><a href="/blog/code-convening-portland">Meet the projects coming to Code Convening&#58; Write The Docs</a> | posted <abbr class="timeago" title="2015-05-16 12:30:00 -0500">2015-05-16 12:30:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/code-convening-portland">Meet the projects coming to Code Convening&#58; Write The Docs</a> | posted <abbr class="timeago" title="2015-05-16 12:30:00 -0400">2015-05-16 12:30:00 -0400</abbr></li></p>
 
-<p>  <li><a href="/blog/code-convening-wtd">Code Convening&#58; Write The Docs. Come open your code with us!</a> | posted <abbr class="timeago" title="2015-04-20 14:00:00 -0500">2015-04-20 14:00:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/code-convening-wtd">Code Convening&#58; Write The Docs. Come open your code with us!</a> | posted <abbr class="timeago" title="2015-04-20 14:00:00 -0400">2015-04-20 14:00:00 -0400</abbr></li></p>
 
 <p>  </ul></p>
 
 <p>  <h3 id="coralproject"><a href="coralproject">coralproject</a></h3>
   <ul></p>
 
-<p>  <li><a href="/blog/coral-andrew">The Coral Project is Go Go Go Go Go</a> | posted <abbr class="timeago" title="2015-04-28 12:30:00 -0500">2015-04-28 12:30:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/coral-andrew">The Coral Project is Go Go Go Go Go</a> | posted <abbr class="timeago" title="2015-04-28 12:30:00 -0400">2015-04-28 12:30:00 -0400</abbr></li></p>
 
 <p>  </ul></p>
 
 <p>  <h3 id="fellowship"><a href="fellowship">fellowship</a></h3>
   <ul></p>
 
-<p>  <li><a href="/blog/fellowship-2016-partner">Hosting a Knight-Mozilla Fellow in 2016</a> | posted <abbr class="timeago" title="2015-04-01 16:15:00 -0500">2015-04-01 16:15:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/fellowship-2016-partner">Hosting a Knight-Mozilla Fellow in 2016</a> | posted <abbr class="timeago" title="2015-04-01 16:15:00 -0400">2015-04-01 16:15:00 -0400</abbr></li></p>
 
-<p>  <li><a href="/blog/introducing-kavya">2015 Fellowship Onboarding is GO</a> | posted <abbr class="timeago" title="2015-01-12 09:00:00 -0600">2015-01-12 09:00:00 -0600</abbr></li></p>
+<p>  <li><a href="/blog/introducing-kavya">2015 Fellowship Onboarding is GO</a> | posted <abbr class="timeago" title="2015-01-12 09:00:00 -0500">2015-01-12 09:00:00 -0500</abbr></li></p>
 
-<p>  <li><a href="/blog/announcing-2015-fellows">Announcing our 2015 Knight-Mozilla Fellows!</a> | posted <abbr class="timeago" title="2014-10-22 09:00:00 -0500">2014-10-22 09:00:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/announcing-2015-fellows">Announcing our 2015 Knight-Mozilla Fellows!</a> | posted <abbr class="timeago" title="2014-10-22 09:00:00 -0400">2014-10-22 09:00:00 -0400</abbr></li></p>
 
 <p>  </ul></p>
 
 <p>  <h3 id="housekeeping"><a href="housekeeping">housekeeping</a></h3>
   <ul></p>
 
-<p>  <li><a href="/blog/new-site">New Year, New Site</a> | posted <abbr class="timeago" title="2015-01-16 10:00:00 -0600">2015-01-16 10:00:00 -0600</abbr></li></p>
+<p>  <li><a href="/blog/new-site">New Year, New Site</a> | posted <abbr class="timeago" title="2015-01-16 10:00:00 -0500">2015-01-16 10:00:00 -0500</abbr></li></p>
 
 <p>  </ul></p>
 
 <p>  <h3 id="srccon"><a href="srccon">srccon</a></h3>
   <ul></p>
 
-<p>  <li><a href="/blog/srccon-tickets">SRCCON Ticketing—What We Did and Why</a> | posted <abbr class="timeago" title="2015-05-12 12:30:00 -0500">2015-05-12 12:30:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/srccon-tickets">SRCCON Ticketing—What We Did and Why</a> | posted <abbr class="timeago" title="2015-05-12 12:30:00 -0400">2015-05-12 12:30:00 -0400</abbr></li></p>
 
-<p>  <li><a href="/blog/srcconqs">Five Reasons You Shouldn&rsquo;t Come to SRCCON (and Why They&rsquo;re All Wrong)</a> | posted <abbr class="timeago" title="2015-04-22 12:00:00 -0500">2015-04-22 12:00:00 -0500</abbr></li></p>
+<p>  <li><a href="/blog/srcconqs">Five Reasons You Shouldn&rsquo;t Come to SRCCON (and Why They&rsquo;re All Wrong)</a> | posted <abbr class="timeago" title="2015-04-22 12:00:00 -0400">2015-04-22 12:00:00 -0400</abbr></li></p>
 
 <p>  </ul></p>
 

--- a/_site/blog/welcome/index.html
+++ b/_site/blog/welcome/index.html
@@ -86,7 +86,7 @@
 <p>Welcome, Lindsay!</p>
 
 </div>
-<small>posted <abbr class="timeago" title="2015-03-26 15:00:00 -0500">2015-03-26 15:00:00 -0500</abbr> | posted in
+<small>posted <abbr class="timeago" title="2015-03-26 15:00:00 -0400">2015-03-26 15:00:00 -0400</abbr> | posted in
 
   
   <a href="/blog/tags/Source">Source</a>&nbsp;

--- a/_site/feed.xml
+++ b/_site/feed.xml
@@ -10,9 +10,9 @@
 <title>Meet the projects coming to Code Convening&amp;#58; Write The Docs</title>
 <dc:creator></dc:creator>
 
-<description>Meet the seven projects we&#39;re bringing to our code convening at Write The Docs 2015.</description>
+<description>Meet the seven projects we're bringing to our code convening at Write The Docs 2015.</description>
 
-<pubDate>Sat, 16 May 2015 12:30:00 -0500</pubDate>
+<pubDate>Sat, 16 May 2015 12:30:00 -0400</pubDate>
 <link>http://www.opennews.org/blog/code-convening-portland</link>
 <guid isPermaLink="true">http://www.opennews.org/blog/code-convening-portland</guid>
 </item>
@@ -21,9 +21,9 @@
 <title>SRCCON Ticketing—What We Did and Why</title>
 <dc:creator></dc:creator>
 
-<description>This year, as we prepare for SRCCON 2015, we&#39;re making an effort to document our work in public as we go. This post on our ticketing process will be followed shortly by one on session selection, with more to come between now and the end of June.</description>
+<description>This year, as we prepare for SRCCON 2015, we're making an effort to document our work in public as we go. This post on our ticketing process will be followed shortly by one on session selection, with more to come between now and the end of June.</description>
 
-<pubDate>Tue, 12 May 2015 12:30:00 -0500</pubDate>
+<pubDate>Tue, 12 May 2015 12:30:00 -0400</pubDate>
 <link>http://www.opennews.org/blog/srccon-tickets</link>
 <guid isPermaLink="true">http://www.opennews.org/blog/srccon-tickets</guid>
 </item>
@@ -34,18 +34,18 @@
 
 <description>Exciting things are happening at &lt;a href=&quot;https://twitter.com/coralproject&quot;&gt;The Coral Project&lt;/a&gt; and we thought you should know about them.</description>
 
-<pubDate>Tue, 28 Apr 2015 12:30:00 -0500</pubDate>
+<pubDate>Tue, 28 Apr 2015 12:30:00 -0400</pubDate>
 <link>http://www.opennews.org/blog/coral-andrew</link>
 <guid isPermaLink="true">http://www.opennews.org/blog/coral-andrew</guid>
 </item>
 
 <item>
-<title>Five Reasons You Shouldn&#39;t Come to SRCCON (and Why They&#39;re All Wrong)</title>
+<title>Five Reasons You Shouldn't Come to SRCCON (and Why They're All Wrong)</title>
 <dc:creator></dc:creator>
 
-<description>Tickets to &lt;a href=&quot;http://srccon.org/&quot;&gt;SRCCON, the OpenNews conference&lt;/a&gt;, go on sale Wednesday, April 29 at 2pm EDT. But maybe you&#39;re still on the fence about SRCCON, or are worried that you won&#39;t quite fit in. If so, worry no longer—instead, check out our five top reasons why you shouldn&#39;t come to SRCCON (and why they&#39;re all wrong).</description>
+<description>Tickets to &lt;a href=&quot;http://srccon.org/&quot;&gt;SRCCON, the OpenNews conference&lt;/a&gt;, go on sale Wednesday, April 29 at 2pm EDT. But maybe you're still on the fence about SRCCON, or are worried that you won't quite fit in. If so, worry no longer—instead, check out our five top reasons why you shouldn't come to SRCCON (and why they're all wrong).</description>
 
-<pubDate>Wed, 22 Apr 2015 12:00:00 -0500</pubDate>
+<pubDate>Wed, 22 Apr 2015 12:00:00 -0400</pubDate>
 <link>http://www.opennews.org/blog/srcconqs</link>
 <guid isPermaLink="true">http://www.opennews.org/blog/srcconqs</guid>
 </item>
@@ -54,20 +54,20 @@
 <title>Code Convening&amp;#58; Write The Docs. Come open your code with us!</title>
 <dc:creator></dc:creator>
 
-<description>We&#39;ll be taking a cohort of news developers and journalists to the Write The Docs conference, May 17-19 in Portland, to write and revise documentation, release the latest version of their open-source projects, and talk journalism with the technical documentation community.</description>
+<description>We'll be taking a cohort of news developers and journalists to the Write The Docs conference, May 17-19 in Portland, to write and revise documentation, release the latest version of their open-source projects, and talk journalism with the technical documentation community.</description>
 
-<pubDate>Mon, 20 Apr 2015 14:00:00 -0500</pubDate>
+<pubDate>Mon, 20 Apr 2015 14:00:00 -0400</pubDate>
 <link>http://www.opennews.org/blog/code-convening-wtd</link>
 <guid isPermaLink="true">http://www.opennews.org/blog/code-convening-wtd</guid>
 </item>
 
 <item>
-<title>Five Things We&#39;ve Learned About Sessions</title>
+<title>Five Things We've Learned About Sessions</title>
 <dc:creator></dc:creator>
 
-<description>As we near the deadline for SRCCON session proposals (April 10, &lt;a href=&quot;http://srccon.org/sessions&quot;&gt;pitch now&lt;/a&gt;) we wanted to share with you some of what we&#39;ve learned about sessions so far. Thank you to everyone who shared feedback about last year&#39;s conference and helped inform &lt;a href=&quot;http://opennews.org/blog/srccon-human-stuff&quot;&gt;how we&#39;re thinking about things&lt;/a&gt; this year.</description>
+<description>As we near the deadline for SRCCON session proposals (April 10, &lt;a href=&quot;http://srccon.org/sessions&quot;&gt;pitch now&lt;/a&gt;) we wanted to share with you some of what we've learned about sessions so far. Thank you to everyone who shared feedback about last year's conference and helped inform &lt;a href=&quot;http://opennews.org/blog/srccon-human-stuff&quot;&gt;how we're thinking about things&lt;/a&gt; this year.</description>
 
-<pubDate>Wed, 08 Apr 2015 18:00:00 -0500</pubDate>
+<pubDate>Wed, 08 Apr 2015 18:00:00 -0400</pubDate>
 <link>http://www.opennews.org/blog/srccon-top5</link>
 <guid isPermaLink="true">http://www.opennews.org/blog/srccon-top5</guid>
 </item>
@@ -76,9 +76,9 @@
 <title>How to plan a great SRCCON session</title>
 <dc:creator></dc:creator>
 
-<description>SRCCON sessions are interactive and collaborative, and if you&#39;ve never led one, it can be hard to know what to expect. Here are some strategies to help you lead a discussion or skillshare that gets everyone involved and leaves everyone energized.</description>
+<description>SRCCON sessions are interactive and collaborative, and if you've never led one, it can be hard to know what to expect. Here are some strategies to help you lead a discussion or skillshare that gets everyone involved and leaves everyone energized.</description>
 
-<pubDate>Tue, 07 Apr 2015 18:00:00 -0500</pubDate>
+<pubDate>Tue, 07 Apr 2015 18:00:00 -0400</pubDate>
 <link>http://www.opennews.org/blog/srccon-session-planning</link>
 <guid isPermaLink="true">http://www.opennews.org/blog/srccon-session-planning</guid>
 </item>
@@ -87,9 +87,9 @@
 <title>Captioning a Multi-Track Conference - How SRCCON Did It</title>
 <dc:creator></dc:creator>
 
-<description>One of the nerdiest elements of our first SRCCON didn&#39;t end up involving code or jokey references. As we were prepping for SRCCON last year, I caught a blog post related to !!Con, &lt;a href=&quot;http://composition.al/blog/2014/05/31/your-next-conference-should-have-real-time-captioning/&quot;&gt;Your next conference should have real-time captioning&lt;/a&gt;. I had never heard of event captioning before. I found the blog post convincing, but we were less than two months away from SRCCON, could we pull off something like this?</description>
+<description>One of the nerdiest elements of our first SRCCON didn't end up involving code or jokey references. As we were prepping for SRCCON last year, I caught a blog post related to !!Con, &lt;a href=&quot;http://composition.al/blog/2014/05/31/your-next-conference-should-have-real-time-captioning/&quot;&gt;Your next conference should have real-time captioning&lt;/a&gt;. I had never heard of event captioning before. I found the blog post convincing, but we were less than two months away from SRCCON, could we pull off something like this?</description>
 
-<pubDate>Thu, 02 Apr 2015 18:00:00 -0500</pubDate>
+<pubDate>Thu, 02 Apr 2015 18:00:00 -0400</pubDate>
 <link>http://www.opennews.org/blog/srccon-transcription</link>
 <guid isPermaLink="true">http://www.opennews.org/blog/srccon-transcription</guid>
 </item>
@@ -98,9 +98,9 @@
 <title>Hosting a Knight-Mozilla Fellow in 2016</title>
 <dc:creator></dc:creator>
 
-<description>Next year will be the fifth year of the Knight-Mozilla Fellowship program and we&#39;re looking for our next group of fellowship partners. If your news organization is interested in hosting a fellow next year, &lt;a href=&quot;http://opennews.org/what/fellowships/partnerguidelines/#form&quot;&gt;fill out this form&lt;/a&gt; by April 24.</description>
+<description>Next year will be the fifth year of the Knight-Mozilla Fellowship program and we're looking for our next group of fellowship partners. If your news organization is interested in hosting a fellow next year, &lt;a href=&quot;http://opennews.org/what/fellowships/partnerguidelines/#form&quot;&gt;fill out this form&lt;/a&gt; by April 24.</description>
 
-<pubDate>Wed, 01 Apr 2015 16:15:00 -0500</pubDate>
+<pubDate>Wed, 01 Apr 2015 16:15:00 -0400</pubDate>
 <link>http://www.opennews.org/blog/fellowship-2016-partner</link>
 <guid isPermaLink="true">http://www.opennews.org/blog/fellowship-2016-partner</guid>
 </item>
@@ -111,7 +111,7 @@
 
 <description>We wanted the attendees of SRCCON to be able to focus on the conference itself—sessions, activities, and other official stuff, but also the conversations in hallways and corners that are usually a highlight of gatherings of enthusiastic colleagues. To make that possible, we tried to arrange the SRCCON schedule, space, and life-support systems to be as accommodating and supportive as possible.</description>
 
-<pubDate>Wed, 01 Apr 2015 09:00:00 -0500</pubDate>
+<pubDate>Wed, 01 Apr 2015 09:00:00 -0400</pubDate>
 <link>http://www.opennews.org/blog/srccon-human-stuff</link>
 <guid isPermaLink="true">http://www.opennews.org/blog/srccon-human-stuff</guid>
 </item>

--- a/_site/index.html
+++ b/_site/index.html
@@ -98,97 +98,97 @@
 <ul class = "bloglist">
   
     <li>
-      <p class="blogtitle"><a href="/blog/code-convening-portland">Meet the projects coming to Code Convening&#58; Write The Docs</a><span class="blogdate">| posted <abbr class="timeago" title="2015-05-16 12:30:00 -0500">2015-05-16 12:30:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/code-convening-portland">Meet the projects coming to Code Convening&#58; Write The Docs</a><span class="blogdate">| posted <abbr class="timeago" title="2015-05-16 12:30:00 -0400">2015-05-16 12:30:00 -0400</abbr></span></>
       <p class="excerpt">Meet the seven projects we're bringing to our code convening at Write The Docs 2015.&nbsp;<a href="/blog/code-convening-portland">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-tickets">SRCCON Ticketing—What We Did and Why</a><span class="blogdate">| posted <abbr class="timeago" title="2015-05-12 12:30:00 -0500">2015-05-12 12:30:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-tickets">SRCCON Ticketing—What We Did and Why</a><span class="blogdate">| posted <abbr class="timeago" title="2015-05-12 12:30:00 -0400">2015-05-12 12:30:00 -0400</abbr></span></>
       <p class="excerpt">This year, as we prepare for SRCCON 2015, we're making an effort to document our work in public as we go. This post on our ticketing process will be followed shortly by one on session selection, with more to come between now and the end of June.&nbsp;<a href="/blog/srccon-tickets">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/coral-andrew">The Coral Project is Go Go Go Go Go</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-28 12:30:00 -0500">2015-04-28 12:30:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/coral-andrew">The Coral Project is Go Go Go Go Go</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-28 12:30:00 -0400">2015-04-28 12:30:00 -0400</abbr></span></>
       <p class="excerpt">Exciting things are happening at <a href="https://twitter.com/coralproject">The Coral Project</a> and we thought you should know about them.&nbsp;<a href="/blog/coral-andrew">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srcconqs">Five Reasons You Shouldn't Come to SRCCON (and Why They're All Wrong)</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-22 12:00:00 -0500">2015-04-22 12:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srcconqs">Five Reasons You Shouldn't Come to SRCCON (and Why They're All Wrong)</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-22 12:00:00 -0400">2015-04-22 12:00:00 -0400</abbr></span></>
       <p class="excerpt">Tickets to <a href="http://srccon.org/">SRCCON, the OpenNews conference</a>, go on sale Wednesday, April 29 at 2pm EDT. But maybe you're still on the fence about SRCCON, or are worried that you won't quite fit in. If so, worry no longer—instead, check out our five top reasons why you shouldn't come to SRCCON (and why they're all wrong).&nbsp;<a href="/blog/srcconqs">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/code-convening-wtd">Code Convening&#58; Write The Docs. Come open your code with us!</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-20 14:00:00 -0500">2015-04-20 14:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/code-convening-wtd">Code Convening&#58; Write The Docs. Come open your code with us!</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-20 14:00:00 -0400">2015-04-20 14:00:00 -0400</abbr></span></>
       <p class="excerpt">We'll be taking a cohort of news developers and journalists to the Write The Docs conference, May 17-19 in Portland, to write and revise documentation, release the latest version of their open-source projects, and talk journalism with the technical documentation community.&nbsp;<a href="/blog/code-convening-wtd">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-top5">Five Things We've Learned About Sessions</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-08 18:00:00 -0500">2015-04-08 18:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-top5">Five Things We've Learned About Sessions</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-08 18:00:00 -0400">2015-04-08 18:00:00 -0400</abbr></span></>
       <p class="excerpt">As we near the deadline for SRCCON session proposals (April 10, <a href="http://srccon.org/sessions">pitch now</a>) we wanted to share with you some of what we've learned about sessions so far. Thank you to everyone who shared feedback about last year's conference and helped inform <a href="http://opennews.org/blog/srccon-human-stuff">how we're thinking about things</a> this year.&nbsp;<a href="/blog/srccon-top5">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-session-planning">How to plan a great SRCCON session</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-07 18:00:00 -0500">2015-04-07 18:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-session-planning">How to plan a great SRCCON session</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-07 18:00:00 -0400">2015-04-07 18:00:00 -0400</abbr></span></>
       <p class="excerpt">SRCCON sessions are interactive and collaborative, and if you've never led one, it can be hard to know what to expect. Here are some strategies to help you lead a discussion or skillshare that gets everyone involved and leaves everyone energized.&nbsp;<a href="/blog/srccon-session-planning">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-transcription">Captioning a Multi-Track Conference - How SRCCON Did It</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-02 18:00:00 -0500">2015-04-02 18:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-transcription">Captioning a Multi-Track Conference - How SRCCON Did It</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-02 18:00:00 -0400">2015-04-02 18:00:00 -0400</abbr></span></>
       <p class="excerpt">One of the nerdiest elements of our first SRCCON didn't end up involving code or jokey references. As we were prepping for SRCCON last year, I caught a blog post related to !!Con, <a href="http://composition.al/blog/2014/05/31/your-next-conference-should-have-real-time-captioning/">Your next conference should have real-time captioning</a>. I had never heard of event captioning before. I found the blog post convincing, but we were less than two months away from SRCCON, could we pull off something like this?&nbsp;<a href="/blog/srccon-transcription">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/fellowship-2016-partner">Hosting a Knight-Mozilla Fellow in 2016</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-01 16:15:00 -0500">2015-04-01 16:15:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/fellowship-2016-partner">Hosting a Knight-Mozilla Fellow in 2016</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-01 16:15:00 -0400">2015-04-01 16:15:00 -0400</abbr></span></>
       <p class="excerpt">Next year will be the fifth year of the Knight-Mozilla Fellowship program and we're looking for our next group of fellowship partners. If your news organization is interested in hosting a fellow next year, <a href="http://opennews.org/what/fellowships/partnerguidelines/#form">fill out this form</a> by April 24.&nbsp;<a href="/blog/fellowship-2016-partner">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-human-stuff">Making SRCCON Good for Humans</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-01 09:00:00 -0500">2015-04-01 09:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-human-stuff">Making SRCCON Good for Humans</a><span class="blogdate">| posted <abbr class="timeago" title="2015-04-01 09:00:00 -0400">2015-04-01 09:00:00 -0400</abbr></span></>
       <p class="excerpt">We wanted the attendees of SRCCON to be able to focus on the conference itself—sessions, activities, and other official stuff, but also the conversations in hallways and corners that are usually a highlight of gatherings of enthusiastic colleagues. To make that possible, we tried to arrange the SRCCON schedule, space, and life-support systems to be as accommodating and supportive as possible.&nbsp;<a href="/blog/srccon-human-stuff">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/welcome">Welcoming Lindsay Muscato</a><span class="blogdate">| posted <abbr class="timeago" title="2015-03-26 15:00:00 -0500">2015-03-26 15:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/welcome">Welcoming Lindsay Muscato</a><span class="blogdate">| posted <abbr class="timeago" title="2015-03-26 15:00:00 -0400">2015-03-26 15:00:00 -0400</abbr></span></>
       <p class="excerpt">After an involved selection process, we are very happy to introduce <a href="http://lindsaymuscato.com">Lindsay Muscato</a>, Source's new assistant editor, who will be working with us on an upcoming site restructure and leading much of the day-to-day editorial work of keeping Source connected to the news code community.&nbsp;<a href="/blog/welcome">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-proposals">SRCCON Needs You</a><span class="blogdate">| posted <abbr class="timeago" title="2015-03-25 12:00:00 -0500">2015-03-25 12:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-proposals">SRCCON Needs You</a><span class="blogdate">| posted <abbr class="timeago" title="2015-03-25 12:00:00 -0400">2015-03-25 12:00:00 -0400</abbr></span></>
       <p class="excerpt"><a href="http://srccon.org">SRCCON is back in 2015</a> for another two days of building better newsroom code, culture, and process, this time in beautiful Minneapolis. And now it's time for you to <a href="http://srccon.org/sessions/">propose a session</a>.&nbsp;<a href="/blog/srccon-proposals">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/nicar">OpenNews at NICAR</a><span class="blogdate">| posted <abbr class="timeago" title="2015-03-04 07:00:00 -0600">2015-03-04 07:00:00 -0600</abbr></span></>
+      <p class="blogtitle"><a href="/blog/nicar">OpenNews at NICAR</a><span class="blogdate">| posted <abbr class="timeago" title="2015-03-04 07:00:00 -0500">2015-03-04 07:00:00 -0500</abbr></span></>
       <p class="excerpt">We're going to be at NICAR in force this year, and we want to see you there.&nbsp;<a href="/blog/nicar">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/srccon-launch">SRCCON 2015 coming to Minneapolis</a><span class="blogdate">| posted <abbr class="timeago" title="2015-02-20 12:00:00 -0600">2015-02-20 12:00:00 -0600</abbr></span></>
+      <p class="blogtitle"><a href="/blog/srccon-launch">SRCCON 2015 coming to Minneapolis</a><span class="blogdate">| posted <abbr class="timeago" title="2015-02-20 12:00:00 -0500">2015-02-20 12:00:00 -0500</abbr></span></>
       <p class="excerpt">We're excited to announce SRCCON 2015, which will take place in Minneapolis, Minnesota on June 25 and 26. We can't wait to spend another two days building better newsroom code, culture, and process—together.&nbsp;<a href="/blog/srccon-launch">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/fellowship-onboarding-ccdc">Fellows Hack with the California Civic Data Coalition</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-26 12:00:00 -0600">2015-01-26 12:00:00 -0600</abbr></span></>
+      <p class="blogtitle"><a href="/blog/fellowship-onboarding-ccdc">Fellows Hack with the California Civic Data Coalition</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-26 12:00:00 -0500">2015-01-26 12:00:00 -0500</abbr></span></>
       <p class="excerpt">During the onboarding week with our new 2015 Knight-Mozilla fellows, we spent a couple days working with the California Civic Data Coalition on an open-source news app. Here's what our goals were, and here's what we learned.&nbsp;<a href="/blog/fellowship-onboarding-ccdc">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/source-hiring">Source is Hiring</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-23 07:00:00 -0600">2015-01-23 07:00:00 -0600</abbr></span></>
+      <p class="blogtitle"><a href="/blog/source-hiring">Source is Hiring</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-23 07:00:00 -0500">2015-01-23 07:00:00 -0500</abbr></span></>
       <p class="excerpt">OpenNews is hiring a part-time assistant editor on a contract basis for Source, our journalism-code community website—and you should totally apply.&nbsp;<a href="/blog/source-hiring">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/new-site">New Year, New Site</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-16 10:00:00 -0600">2015-01-16 10:00:00 -0600</abbr></span></>
+      <p class="blogtitle"><a href="/blog/new-site">New Year, New Site</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-16 10:00:00 -0500">2015-01-16 10:00:00 -0500</abbr></span></>
       <p class="excerpt">While our 2015 Knight-Mozilla fellows have been in Los Angeles, getting to know each other and the world of newsroom code, we’ve given OpenNews.org a haircut and re-org to reflect the work we’re actually doing.&nbsp;<a href="/blog/new-site">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/introducing-kavya">2015 Fellowship Onboarding is GO</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-12 09:00:00 -0600">2015-01-12 09:00:00 -0600</abbr></span></>
+      <p class="blogtitle"><a href="/blog/introducing-kavya">2015 Fellowship Onboarding is GO</a><span class="blogdate">| posted <abbr class="timeago" title="2015-01-12 09:00:00 -0500">2015-01-12 09:00:00 -0500</abbr></span></>
       <p class="excerpt">The OpenNews team brings our 2015 Knight-Mozilla Fellows to Los Angeles to start the work of their fellowship years. We also welcome Kavya Sukumar as our seventh 2015 fellow, who will spend her fellowship year working with Vox Media. Yay fellows! Yay Los Angeles!&nbsp;<a href="/blog/introducing-kavya">read more</a>
     </li>
   
     <li>
-      <p class="blogtitle"><a href="/blog/announcing-2015-fellows">Announcing our 2015 Knight-Mozilla Fellows!</a><span class="blogdate">| posted <abbr class="timeago" title="2014-10-22 09:00:00 -0500">2014-10-22 09:00:00 -0500</abbr></span></>
+      <p class="blogtitle"><a href="/blog/announcing-2015-fellows">Announcing our 2015 Knight-Mozilla Fellows!</a><span class="blogdate">| posted <abbr class="timeago" title="2014-10-22 09:00:00 -0400">2014-10-22 09:00:00 -0400</abbr></span></>
       <p class="excerpt">Live from the 2014 Mozilla Festival in London, we're thrilled to introduce our 2015 Knight-Mozilla Fellows. The work that the Knight-Mozilla Fellows do during their fellowship year doesn't fit easily into a single sentence. Over the year a fellow will play the role of coder, teacher, mentor (and mentee), adventurer, colleague, and friend. They'll push themselves, and journalism, in new directions. They'll do work that has real impact--on themselves and on the web. It's a tall order, but a thrilling one, and the people we have lined up to do the work of a Knight-Mozilla Fellow in 2015 are among our very best yet. I can't wait for you to meet them.&nbsp;<a href="/blog/announcing-2015-fellows">read more</a>
     </li>
   

--- a/_site/what/fellowships/apply/index.html
+++ b/_site/what/fellowships/apply/index.html
@@ -99,7 +99,7 @@
 <h2>Application Now Closed. Thank You!</h2>
 
 
-<p>Thank you for your interest in the Knight-Mozilla Fellowships. As of 12:01am August 17, 2014, we have ended the search for our 2015 Knight-Mozilla Fellows. We will be announcing our new fellows at the <a href="http://2014.mozillafestival.org/">2014 Mozilla Festival</a> in London.</p>
+<p>Thank you for your interest in the Knight-Mozilla Fellowships. On June 10, 2015 we will update this page with the application for the 2016 Knight-Mozilla Fellowship. The application will be open until August 21, 2015.</p>
 
 </div>
 

--- a/_site/what/fellowships/faq/index.html
+++ b/_site/what/fellowships/faq/index.html
@@ -97,46 +97,7 @@
 </div>
 
 <h2>The Knight-Mozilla Fellowships&colon; How to Apply</h2>
-<p><p class="bodybig">The application to become a 2015 Knight-Mozilla Fellow opened on June 16 and closed August 16, 2014. <a href="/fellowships/2015meet">We announced our 2015 Fellows</a> at the <a href="http://www.mozillafestival.org">Mozilla Festival</a> in London, October 24-26. We will start our search for our 2016 Fellows in early summer, 2015.</p>
-
-<h3>How does the application review and matching process work?</h3>
-
-<p>Applications are submitted through a Screendoor form and are visible at the time they are submitted, but formal review does not begin until after the application deadline closes on August 16.</p>
-
-<p><strong>Initial review</strong></p>
-
-<ul>
-<li>OpenNews staff review all of the applications and cull the batch to a manageable number for the news partners to review.</li>
-<li>The news partners review this shorter list and submit a list of the five people they are most interested in learning more about.</li>
-<li>These semifinalists are contacted for interviews. Applicants who are not moving forward in the selection process are notified.</li>
-</ul>
-
-
-<p><strong>Semifinalists</strong></p>
-
-<ul>
-<li>Dan and Erika conduct short, standardized interviews with the semifinalists, asking a few questions that are about vision and skills/practical considerations.</li>
-<li>The notes from these interviews are submitted back to the news partners for review, and the news partners are able to pick their top three finalists from the entire pool of semifinalists, not just the five they initially submitted. (Last year there was a lot of crossover at this stage.)</li>
-<li>The semifinalists who are not moving forward are notified of their application status.</li>
-</ul>
-
-
-<p><strong>Finalists</strong></p>
-
-<ul>
-<li>The news organization and OpenNews has a much longer interview with each of that news organization’s top three candidates. This interview is a chance for the news partner and the finalist to learn more about each other and what to expect from a Fellowship at that news organization.</li>
-<li>In consultation with OpenNews and the news partners, the final Fellow selection is made for each news organization.</li>
-</ul>
-
-
-<p><strong>Fellowship Announcements</strong></p>
-
-<ul>
-<li>The selected Fellows are notified and given an opportunity to ask additional questions of the news partner and OpenNews.</li>
-<li>The finalists that were not selected as Fellows are notified of their application status.</li>
-<li>A public announcement of the Fellows is made at the <a href="http://www.mozillafestival.org">Mozilla Festival</a>.</li>
-</ul>
-
+<p><p class="bodybig">The application to become a 2016 Knight-Mozilla Fellow will open on June 10, 2015. It will remain open until August 21, 2015.</p>
 
 <h3>Common Questions</h3>
 
@@ -170,7 +131,7 @@
 
 <p><strong>Are you still accepting applications for host newsrooms?</strong></p>
 
-<p>No, we are not accepting host newsroom applications at this time—but we will be again in the spring of 2015.</p>
+<p>No, we are not accepting host newsroom applications at this time—but we will be again in the spring of 2016.</p>
 
 <p><strong>How do I contact you?</strong></p>
 

--- a/_site/what/fellowships/index.html
+++ b/_site/what/fellowships/index.html
@@ -108,7 +108,9 @@
 
 
 
-<p><p class="bodybig">The Knight-Mozilla Fellowships bring together developers, technologists, civic hackers, and data crunchers to spend 10 months working on open source code with partner newsroom. Knight-Mozilla Fellows write code, spread ideas, and help build community during their fellowship year.
+<p><p class="bodybig">The Knight-Mozilla Fellowships bring together developers, technologists, civic hackers, and data crunchers to spend 10 months working on open source code with partner newsroom. Knight-Mozilla Fellows write code, spread ideas, and help build community during their fellowship year.</p>
+
+<p><p class="bodybig">On June 10, applications will open for the 2016 Knight Mozilla Fellows.
 <p><a href="2015meet">Meet our 2015 Knight Mozilla Fellows</a>
 </p></p>
 
@@ -122,6 +124,10 @@
 <a href="http://www.washingtonpost.com/" class="logo-wp">Washington Post</a>
 <a href="http://cironline.org/" class="logo-cir">Center for Investigative Reporting</a>
 </div></p>
+
+<h3>The 2016 Fellowships</h3>
+
+<p>We are currently in the midst of planning the 2016 fellowships. We will launch the application for fellows on June 10, 2015 and it will close on August 21, 2015.</p>
 
 <h3>The 2015 Fellowships</h3>
 

--- a/_site/what/fellowships/info/index.html
+++ b/_site/what/fellowships/info/index.html
@@ -102,42 +102,32 @@
 
 <h3>FELLOWSHIP TIMELINE</h3>
 
-<p>2015 Fellowships begin in calendar year 2015 and last for 10 months. Each Fellow&rsquo;s start date will be individualized for the needs of that Fellow and the news organization, but most Fellowships will begin in February or March of 2015.</p>
+<p>The application for the 2016 fellowship will be open from June 10 to August 21, 2015.</p>
+
+<p>The 2016 fellowships begin in calendar year 2016 and last for 10 months. Each fellow&rsquo;s start date will be individualized for the needs of that fellow and the news organization, but most fellowships will begin in February or March of 2016.</p>
 
 <h3>FELLOWSHIP LOCATIONS</h3>
 
-<p>Fellows are based, unless special circumstances dictate, in the town of their host news organization.
-In 2015, the Fellows will be based with:</p>
+<p>Fellows are based, unless special circumstances dictate, in the town of their host news organization. We are in the process of selecting the news organizations that will host fellows in 2016 and will announce the organizations and their locations on June 10, 2015.</p>
 
-<ul>
-<li>The Guardian in London, UK</li>
-<li>La Nacion in Buenos Aires, Argentina</li>
-<li>NPR in Washington, DC</li>
-<li>Vox Media in Austin, TX; Washington, DC; or New York, NY</li>
-<li>Center for Investigative Reporting in Emeryville, CA (just outside San Francisco)</li>
-<li>New York Times in New York, NY</li>
-<li>Washington Post in Washington, DC; or New York, NY</li>
-</ul>
-
-
-<p>We make every attempt to match skills of Fellows with needs of news organizations when matching Fellow to organization.</p>
+<p>We make every attempt to match skills of fellows with needs of news organizations when matching fellow to organization.</p>
 
 <h3>STIPEND AND FINANCIAL BENEFITS</h3>
 
-<p>The Knight-Mozilla Fellowship is designed to allow flexibility for both Fellows and Fellowship Partners. <strong>The standard Fellowship offers a stipend of $60,000, paid in 10 monthly installments.</strong> Fellows are responsible for remitting all applicable taxes and other government payments as required.</p>
+<p>The Knight-Mozilla Fellowship is designed to allow flexibility for both fellows and fellowship Partners. <strong>The standard Fellowship offers a stipend of $60,000, paid in 10 monthly installments.</strong> Fellows are responsible for remitting all applicable taxes and other government payments as required.</p>
 
-<p>Mozilla may, in consultation with Fellows and Fellowship Partners, elect to vary the amount and duration to accommodate the needs and availability of individual fellows and newsrooms.</p>
+<p>Mozilla may, in consultation with fellows and fellowship partners, elect to vary the amount and duration to accommodate the needs and availability of individual fellows and newsrooms.</p>
 
-<p>To help offset cost of living, the Fellowship also provides supplements for childcare and health insurance, and helps pay for research/equipment and books. If you relocate for a fellowship, we will also supplement your housing and moving expenses. The Fellowship also covers the costs of required travel for Fellowship activities.</p>
+<p>To help offset cost of living, the fellowship also provides supplements for childcare and health insurance, and helps pay for research/equipment and books. If you relocate for a fellowship, we will also supplement your housing and moving expenses. The fellowship also covers the costs of required travel for fellowship activities.</p>
 
 <p>Supplements below listed as yearly maximums.</p>
 
-<h3>Housing Supplement (for relocating Fellows only)</h3>
+<h3>Housing Supplement</h3>
 
 
 <table>
 <tr>
-<td>Single, married or partnered Fellow
+<td>Single, married or partnered fellow
 <td>$5,000
 </tr>
 <tr>
@@ -189,17 +179,17 @@ In 2015, the Fellows will be based with:</p>
 <h3>Health Insurance Supplement</h3>
 
 
-<p>The Fellowship pays a health insurance supplement for Fellows and their families, ranging from $3,500 for single Fellows to $7,000 for a couple with two or more children. Funds are provided by way of monthly reimbursement.</p>
+<p>The fellowship pays a health insurance supplement for fellows and their families, ranging from $3,500 for single fellows to $7,000 for a couple with two or more children. Funds are provided by way of monthly reimbursement.</p>
 
 <h3>Moving Allowance</h3>
 
 
-<p>Up to $2,000 for Fellows moving between cities within their country of origin. Up to $4,000 for Fellows moving outside their country of origin. The Fellowship also offers a supplemental allowance for families with children of up to $2,000.</p>
+<p>Up to $2,000 for fellows moving between cities within their country of origin. Up to $4,000 for fellows moving outside their country of origin. The fellowship also offers a supplemental allowance for families with children of up to $2,000.</p>
 
 <h3>Research & Equipment</h3>
 
 
-<p>Up to $3,000 annually will be given towards the purchase of laptop computers, digital cameras, recorders, fees for Continuing Studies or other courses related to the Fellowship, computer software, research fees or payments, and travel expenses for conferences or other research related to the Fellow’s research or study.</p>
+<p>Up to $3,000 annually will be given towards the purchase of laptop computers, digital cameras, recorders, fees for Continuing Studies or other courses related to the fellowship, computer software, research fees or payments, and travel expenses for conferences or other research related to the fellow’s research or study.</p>
 
 <h3>Server Allowance</h3>
 
@@ -209,12 +199,12 @@ In 2015, the Fellows will be based with:</p>
 <h3>Travel Allowance</h3>
 
 
-<p>All approved Fellowship trips – domestic and international – are covered. Additional travel required by the Fellowship Partners will be covered by them.</p>
+<p>All approved fellowship trips – domestic and international – are covered. Additional travel required by the fellowship partners will be covered by them.</p>
 
 <h3>Visa Assistance</h3>
 
 
-<p>Mozilla will work directly with Fellowship Partners to secure temporary work visas on behalf of Fellows who require them.</p>
+<p>Mozilla will work directly with fellowship partners to secure temporary work visas on behalf of fellows who require them.</p>
 
 </div>
 

--- a/what/fellowships/apply/index.md
+++ b/what/fellowships/apply/index.md
@@ -7,4 +7,4 @@ sub-section: fellows_apply
 
 <h2>{{ page.title }}</h2>
 
-Thank you for your interest in the Knight-Mozilla Fellowships. As of 12:01am August 17, 2014, we have ended the search for our 2015 Knight-Mozilla Fellows. We will be announcing our new fellows at the [2014 Mozilla Festival](http://2014.mozillafestival.org/) in London.
+Thank you for your interest in the Knight-Mozilla Fellowships. On June 10, 2015 we will update this page with the application for the 2016 Knight-Mozilla Fellowship. The application will be open until August 21, 2015.

--- a/what/fellowships/faq/index.md
+++ b/what/fellowships/faq/index.md
@@ -5,33 +5,7 @@ section: fellowships
 sub-section: fellows_faq
 ---
 
-<p class="bodybig">The application to become a 2015 Knight-Mozilla Fellow opened on June 16 and closed August 16, 2014. <a href="/fellowships/2015meet">We announced our 2015 Fellows</a> at the <a href="http://www.mozillafestival.org">Mozilla Festival</a> in London, October 24-26. We will start our search for our 2016 Fellows in early summer, 2015.
-
-###How does the application review and matching process work?
-Applications are submitted through a Screendoor form and are visible at the time they are submitted, but formal review does not begin until after the application deadline closes on August 16.
-
-**Initial review**
-
-* OpenNews staff review all of the applications and cull the batch to a manageable number for the news partners to review.
-* The news partners review this shorter list and submit a list of the five people they are most interested in learning more about.
-* These semifinalists are contacted for interviews. Applicants who are not moving forward in the selection process are notified.
-
-**Semifinalists**
-
-* Dan and Erika conduct short, standardized interviews with the semifinalists, asking a few questions that are about vision and skills/practical considerations.
-* The notes from these interviews are submitted back to the news partners for review, and the news partners are able to pick their top three finalists from the entire pool of semifinalists, not just the five they initially submitted. (Last year there was a lot of crossover at this stage.)
-* The semifinalists who are not moving forward are notified of their application status.
-
-**Finalists**
-
-* The news organization and OpenNews has a much longer interview with each of that news organization’s top three candidates. This interview is a chance for the news partner and the finalist to learn more about each other and what to expect from a Fellowship at that news organization.
-* In consultation with OpenNews and the news partners, the final Fellow selection is made for each news organization.
-
-**Fellowship Announcements**
-
-* The selected Fellows are notified and given an opportunity to ask additional questions of the news partner and OpenNews.
-* The finalists that were not selected as Fellows are notified of their application status.
-* A public announcement of the Fellows is made at the [Mozilla Festival](http://www.mozillafestival.org).
+<p class="bodybig">The application to become a 2016 Knight-Mozilla Fellow will open on June 10, 2015. It will remain open until August 21, 2015.
 
 ###Common Questions
 
@@ -65,7 +39,7 @@ In terms of assessing the applicant pool, what has remained consistent each year
 
 **Are you still accepting applications for host newsrooms?**
 
-No, we are not accepting host newsroom applications at this time—but we will be again in the spring of 2015.
+No, we are not accepting host newsroom applications at this time—but we will be again in the spring of 2016.
 
 **How do I contact you?**
 

--- a/what/fellowships/index.md
+++ b/what/fellowships/index.md
@@ -11,6 +11,8 @@ sub-section: fellows_home
 <h2>{{ page.title }}</h2>
 
 <p class="bodybig">The Knight-Mozilla Fellowships bring together developers, technologists, civic hackers, and data crunchers to spend 10 months working on open source code with partner newsroom. Knight-Mozilla Fellows write code, spread ideas, and help build community during their fellowship year.
+
+<p class="bodybig">On June 10, applications will open for the 2016 Knight Mozilla Fellows. 
 <p><a href="2015meet">Meet our 2015 Knight Mozilla Fellows</a>
 </p>
 
@@ -24,6 +26,10 @@ sub-section: fellows_home
 <a href="http://www.washingtonpost.com/" class="logo-wp">Washington Post</a>
 <a href="http://cironline.org/" class="logo-cir">Center for Investigative Reporting</a>
 </div>
+
+###The 2016 Fellowships
+We are currently in the midst of planning the 2016 fellowships. We will launch the application for fellows on June 10, 2015 and it will close on August 21, 2015.
+
 ###The 2015 Fellowships
 Seven news organizations around the world will host our Knight-Mozilla Fellows in 2015: the Guardian, La Nacion, NPR, Vox Media, the Center for Investigative Reporting, the New York Times, and the Washington Post.
 

--- a/what/fellowships/info/index.md
+++ b/what/fellowships/info/index.md
@@ -7,35 +7,28 @@ sub-section: fellows_info
 <p class="bodybig">The Knight-Mozilla fellowships present a unique opportunity for people who like to code and who want to influence the future of journalism on the web. </p>
 
 ###FELLOWSHIP TIMELINE
-2015 Fellowships begin in calendar year 2015 and last for 10 months. Each Fellow's start date will be individualized for the needs of that Fellow and the news organization, but most Fellowships will begin in February or March of 2015.
+The application for the 2016 fellowship will be open from June 10 to August 21, 2015.
+
+The 2016 fellowships begin in calendar year 2016 and last for 10 months. Each fellow's start date will be individualized for the needs of that fellow and the news organization, but most fellowships will begin in February or March of 2016.
 
 ###FELLOWSHIP LOCATIONS
-Fellows are based, unless special circumstances dictate, in the town of their host news organization.
-In 2015, the Fellows will be based with:
+Fellows are based, unless special circumstances dictate, in the town of their host news organization. We are in the process of selecting the news organizations that will host fellows in 2016 and will announce the organizations and their locations on June 10, 2015.
 
-* The Guardian in London, UK
-* La Nacion in Buenos Aires, Argentina
-* NPR in Washington, DC
-* Vox Media in Austin, TX; Washington, DC; or New York, NY
-* Center for Investigative Reporting in Emeryville, CA (just outside San Francisco)
-* New York Times in New York, NY
-* Washington Post in Washington, DC; or New York, NY
-
-We make every attempt to match skills of Fellows with needs of news organizations when matching Fellow to organization.
+We make every attempt to match skills of fellows with needs of news organizations when matching fellow to organization.
 
 ###STIPEND AND FINANCIAL BENEFITS
-The Knight-Mozilla Fellowship is designed to allow flexibility for both Fellows and Fellowship Partners. **The standard Fellowship offers a stipend of $60,000, paid in 10 monthly installments.** Fellows are responsible for remitting all applicable taxes and other government payments as required.
+The Knight-Mozilla Fellowship is designed to allow flexibility for both fellows and fellowship Partners. **The standard Fellowship offers a stipend of $60,000, paid in 10 monthly installments.** Fellows are responsible for remitting all applicable taxes and other government payments as required.
 
-Mozilla may, in consultation with Fellows and Fellowship Partners, elect to vary the amount and duration to accommodate the needs and availability of individual fellows and newsrooms.
+Mozilla may, in consultation with fellows and fellowship partners, elect to vary the amount and duration to accommodate the needs and availability of individual fellows and newsrooms.
 
-To help offset cost of living, the Fellowship also provides supplements for childcare and health insurance, and helps pay for research/equipment and books. If you relocate for a fellowship, we will also supplement your housing and moving expenses. The Fellowship also covers the costs of required travel for Fellowship activities.
+To help offset cost of living, the fellowship also provides supplements for childcare and health insurance, and helps pay for research/equipment and books. If you relocate for a fellowship, we will also supplement your housing and moving expenses. The fellowship also covers the costs of required travel for fellowship activities.
 
 Supplements below listed as yearly maximums.
 
-<h3>Housing Supplement (for relocating Fellows only)</h3>
+<h3>Housing Supplement</h3>
 <table>
 <tr>
-<td>Single, married or partnered Fellow
+<td>Single, married or partnered fellow
 <td>$5,000
 </tr>
 <tr>
@@ -79,19 +72,19 @@ Supplements below listed as yearly maximums.
 <small>* Age defined on March 31 of application year.</small>
 
 <h3>Health Insurance Supplement</h3>
-The Fellowship pays a health insurance supplement for Fellows and their families, ranging from $3,500 for single Fellows to $7,000 for a couple with two or more children. Funds are provided by way of monthly reimbursement.
+The fellowship pays a health insurance supplement for fellows and their families, ranging from $3,500 for single fellows to $7,000 for a couple with two or more children. Funds are provided by way of monthly reimbursement.
 
 <h3>Moving Allowance</h3>
-Up to $2,000 for Fellows moving between cities within their country of origin. Up to $4,000 for Fellows moving outside their country of origin. The Fellowship also offers a supplemental allowance for families with children of up to $2,000.
+Up to $2,000 for fellows moving between cities within their country of origin. Up to $4,000 for fellows moving outside their country of origin. The fellowship also offers a supplemental allowance for families with children of up to $2,000.
 
 <h3>Research & Equipment</h3>
-Up to $3,000 annually will be given towards the purchase of laptop computers, digital cameras, recorders, fees for Continuing Studies or other courses related to the Fellowship, computer software, research fees or payments, and travel expenses for conferences or other research related to the Fellow’s research or study.
+Up to $3,000 annually will be given towards the purchase of laptop computers, digital cameras, recorders, fees for Continuing Studies or other courses related to the fellowship, computer software, research fees or payments, and travel expenses for conferences or other research related to the fellow’s research or study.
 
 <h3>Server Allowance</h3>
 Up to $250 to cover the server costs associated with deploying projects such as fees for Heroku, Amazon Web Services, and domain registration.
 
 <h3>Travel Allowance</h3>
-All approved Fellowship trips – domestic and international – are covered. Additional travel required by the Fellowship Partners will be covered by them.
+All approved fellowship trips – domestic and international – are covered. Additional travel required by the fellowship partners will be covered by them.
 
 <h3>Visa Assistance</h3>
-Mozilla will work directly with Fellowship Partners to secure temporary work visas on behalf of Fellows who require them.
+Mozilla will work directly with fellowship partners to secure temporary work visas on behalf of fellows who require them.


### PR DESCRIPTION
@sinker could you take a look at this? it's mostly just adding the date the application will be open and not editing much else, *except* i removed that housing is "for relocating fellows only." i checked my nots and i think we officially decided that, but wanted to call it out to you before making it public. (I think it is worth changing at this point as it's a question we get a lot as people consider applying.)