### PR TITLE
updated fellowship partner info to remove april reference

### DIFF
--- a/_site/what/fellowships/partnerguidelines/index.html
+++ b/_site/what/fellowships/partnerguidelines/index.html
@@ -112,7 +112,7 @@
 </ul>
 
 
-<p>We are not currently looking for newsrooms to join us as fellowship partners. We expect to start a new search for our 2017 partners in April 2016. OpenNews is much more than fellowships, however. Please <a href="/getinvolved/newspartners/">check out the other ways</a> OpenNews partners with newsrooms.</p>
+<p>We are not currently looking for newsrooms to join us as fellowship partners. If you would like to be notified when the search opens, <a href="info@opennews.org">email us</a>. OpenNews is much more than fellowships, however. Please <a href="/getinvolved/newspartners/">check out the other ways</a> OpenNews partners with newsrooms.</p>
 
 </div>
 

--- a/_site/what/fellowships/partners/index.html
+++ b/_site/what/fellowships/partners/index.html
@@ -112,7 +112,7 @@
 <p class="bodybig"> Fellowship partners host fellows for 10 months, offering challenging projects and immersion into the culture of the newsroom. We select partners who are invested in open source development and who will encourage their fellow to collaborate within and outside of their news organization.</p>
 
 
-<p>We will begin the search for partners for our next cohort of partners in April 2016. If you would like to be notified when the search opens, <a href="mailto:info@opennews.org">email us</a>.</p>
+<p>We are not yet seeking out partners for our next cohort of fellowship partners. If you would like to be notified when the search opens, <a href="mailto:info@opennews.org">email us</a>.</p>
 
 
 <h3>The 2016 partners</h3>
@@ -149,7 +149,7 @@
 
 <h3>Partnering with OpenNews</h3>
 
-<p>Being  a fellowship partner is the most intensive way that OpenNews  collaborates with news organizations, but it is just one of <a href="https://opennews.org/getinvolved/newspartners/">many ways  that we partner</a>  with news orgs. Through our website Source and events like SRCCON, we  partner with news organizations and their teams to share their work. We  also host events called code convenings to help teams open source  projects. And each spring, we put a call out for applications from news  organizations that <a href="https://opennews.org/what/fellowships/partnerguidelines/">would like to host a fellow</a>.</p>
+<p>Being  a fellowship partner is the most intensive way that OpenNews  collaborates with news organizations, but it is just one of <a href="/getinvolved/newspartners/">many ways  that we partner</a> with news orgs. Through our website Source and events like SRCCON, we  partner with news organizations and their teams to share their work. We  also host events called code convenings to help teams open source  projects. During the year, we put a call out for applications from news organizations that <a href="/what/fellowships/partnerguidelines/">would like to host a fellow</a>.</p>
 
 </div>
 

--- a/what/fellowships/partnerguidelines/index.md
+++ b/what/fellowships/partnerguidelines/index.md
@@ -13,4 +13,4 @@ We look for fellowship partners who:
 * commit to being involved in other OpenNews endeavors, including Source and code convenings
 * commit to cover travel costs for a representative to attend a total of four OpenNews related events (two years of the annual Mozilla Festival, an onboarding event, and one other event)
 
-We are not currently looking for newsrooms to join us as fellowship partners. We expect to start a new search for our 2017 partners in April 2016. OpenNews is much more than fellowships, however. Please [check out the other ways](/getinvolved/newspartners/) OpenNews partners with newsrooms.
+We are not currently looking for newsrooms to join us as fellowship partners. If you would like to be notified when the search opens, [email us](info@opennews.org). OpenNews is much more than fellowships, however. Please [check out the other ways](/getinvolved/newspartners/) OpenNews partners with newsrooms.

--- a/what/fellowships/partnerguidelines/index.md~
+++ b/what/fellowships/partnerguidelines/index.md~
@@ -13,4 +13,4 @@ We look for fellowship partners who:
 * commit to being involved in other OpenNews endeavors, including Source and code convenings
 * commit to cover travel costs for a representative to attend a total of four OpenNews related events (two years of the annual Mozilla Festival, an onboarding event, and one other event)
 
-We are not currently looking for newsrooms to join us as fellowship partners. We expect to start a new search for our 2017 partners in the spring of 2016. OpenNews is much more than fellowships, however. Please [check out the other ways](/getinvolved/newspartners/) OpenNews partners with newsrooms.
+We are not currently looking for newsrooms to join us as fellowship partners. If you would like to be notified when the search opens, [email us](info@opennews.org). OpenNews is much more than fellowships, however. Please [check out the other ways](/getinvolved/newspartners/) OpenNews partners with newsrooms.

--- a/what/fellowships/partners/index.md
+++ b/what/fellowships/partners/index.md
@@ -10,7 +10,7 @@ section: partnerships
 <h2>{{ page.title }}</h2>
 
 <p class="bodybig"> Fellowship partners host fellows for 10 months, offering challenging projects and immersion into the culture of the newsroom. We select partners who are invested in open source development and who will encourage their fellow to collaborate within and outside of their news organization.</p>
-<p>We will begin the search for partners for our next cohort of partners in April 2016. If you would like to be notified when the search opens, <a href="mailto:info@opennews.org">email us</a>.</p>
+<p>We are not yet seeking out partners for our next cohort of fellowship partners. If you would like to be notified when the search opens, <a href="mailto:info@opennews.org">email us</a>.</p>
 
 ### The 2016 partners
 We heard from over 40 news organizations that wanted to welcome a fellow for 2016. We selected a mix of partners who have not hosted a fellow before as well as returning partners. In 2016 fellows will be hosted by:
@@ -37,4 +37,4 @@ Over  the years, we've worked with news organizations in the US, Argentina,  the
 
 
 ### Partnering with OpenNews
-Being  a fellowship partner is the most intensive way that OpenNews  collaborates with news organizations, but it is just one of [many ways  that we partner](https://opennews.org/getinvolved/newspartners/)  with news orgs. Through our website Source and events like SRCCON, we  partner with news organizations and their teams to share their work. We  also host events called code convenings to help teams open source  projects. And each spring, we put a call out for applications from news  organizations that [would like to host a fellow](https://opennews.org/what/fellowships/partnerguidelines/).
+Being  a fellowship partner is the most intensive way that OpenNews  collaborates with news organizations, but it is just one of [many ways  that we partner](/getinvolved/newspartners/) with news orgs. Through our website Source and events like SRCCON, we  partner with news organizations and their teams to share their work. We  also host events called code convenings to help teams open source  projects. During the year, we put a call out for applications from news organizations that [would like to host a fellow](/what/fellowships/partnerguidelines/).

--- a/what/fellowships/partners/index.md~
+++ b/what/fellowships/partners/index.md~
@@ -1,10 +1,16 @@
 ---
-layout: fellowship_post
+layout: fellowship_index
 title: The Knight-Mozilla Fellowships&colon; Fellowship Partners
 section: partnerships
 ---
+
+<img src="/media/img/2015_fellows_latimes3.jpg" alt="Our 2015 Fellows explore journalism code." style="width: 100%;">
+<p class="caption">The 2015 fellows visit the Los Angeles Times</p>
+
+<h2>{{ page.title }}</h2>
+
 <p class="bodybig"> Fellowship partners host fellows for 10 months, offering challenging projects and immersion into the culture of the newsroom. We select partners who are invested in open source development and who will encourage their fellow to collaborate within and outside of their news organization.</p>
-<p>We will begin the search for partners for our next cohort of partners in April 2016. If you would like to be notified when the search opens, <a href="mailto:info@opennews.org">email us</a>.</p>
+<p>We are not yet seeking out partners for our next cohort of fellowship partners. If you would like to be notified when the search opens, <a href="mailto:info@opennews.org">email us</a>.</p>
 
 ### The 2016 partners
 We heard from over 40 news organizations that wanted to welcome a fellow for 2016. We selected a mix of partners who have not hosted a fellow before as well as returning partners. In 2016 fellows will be hosted by:
@@ -16,7 +22,7 @@ We heard from over 40 news organizations that wanted to welcome a fellow for 201
 * [NPR](http://blog.apps.npr.org/2015/08/10/knight-mozilla.html) - Washington, DC
 * [Vox Media](http://product.voxmedia.com/2015/8/13/9132033/you-should-be-the-vox-media-2016-opennews-fellow) - Austin, TX; New York, NY; or Washington, DC
 
-One fellow will work from each newsroom (with the exception of The Coral Project, which hosts two fellows) to create open-source code and contribute to journalism projects.
+One fellow will work from each newsroom (with the exception of the Coral Project, which hosts two fellows) to create open-source code and contribute to journalism projects.
 
 ### Working with a fellow
 Hosting a fellow is different from adding another member to the team. Fellows collaborate with newsroom technology teams working on projects that are both editorial and technical. But fellows also have the chance to collaborate  with other folks in the newsroom, with the other fellows in their cohort, and wider journalism-code community. Fellowship partners provide a homebase for fellows and continuity of work and connection, while also leaving room for exploration. Fellows and their newsroom partners work together to decide on projects to work on before their fellowship,  with the support of OpenNews. They also leave ample room for those ideas  evolving over the course of the fellowship.
@@ -31,4 +37,4 @@ Over  the years, we've worked with news organizations in the US, Argentina,  the
 
 
 ### Partnering with OpenNews
-Being  a fellowship partner is the most intensive way that OpenNews  collaborates with news organizations, but it is just one of [many ways  that we partner](https://opennews.org/getinvolved/newspartners/)  with news orgs. Through our website Source and events like SRCCON, we  partner with news organizations and their teams to share their work. We  also host events called code convenings to help teams open source  projects. And each spring, we put a call out for applications from news  organizations that [would like to host a fellow](https://opennews.org/what/fellowships/partnerguidelines/).
+Being  a fellowship partner is the most intensive way that OpenNews  collaborates with news organizations, but it is just one of [many ways  that we partner](https://opennews.org/getinvolved/newspartners/) with news orgs. Through our website Source and events like SRCCON, we  partner with news organizations and their teams to share their work. We  also host events called code convenings to help teams open source  projects. During the year, we put a call out for applications from news organizations that [would like to host a fellow](https://opennews.org/what/fellowships/partnerguidelines/).


### PR DESCRIPTION
people are confused because it is now after april and we have not yet launched the process. i said just email us to get on the list for when we do open it.